### PR TITLE
Use `webNavigation` events if available to improve reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"dependencies": {
-		"content-scripts-register-polyfill": "^2.2.0",
+		"content-scripts-register-polyfill": "^2.2.0-2",
 		"webext-additional-permissions": "^2.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webext-dynamic-content-scripts",
-	"version": "7.1.2",
+	"version": "7.2.0-0",
 	"description": "WebExtension module: Automatically registers your `content_scripts` on domains added via `permission.request`",
 	"keywords": [
 		"contentscript",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		}
 	},
 	"dependencies": {
-		"content-scripts-register-polyfill": "^2.1.2",
+		"content-scripts-register-polyfill": "^2.2.0",
 		"webext-additional-permissions": "^2.0.1"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,18 @@ Include `webext-dynamic-content-scripts` as a background script and add `optiona
 }
 ```
 
+## Permissions for Chrome
+
+This section does not apply to Firefox users.
+
+In order to use `all_frames: true` you should the add [`webNavigation` permission](https://developer.chrome.com/docs/extensions/reference/webNavigation/). Without it, `all_frames: true` won’t work:
+
+- when the iframe is not on the same domain as the top frame
+- when the iframe reloads or navigates to another page
+- when the iframe is not ready when `runAt` is configured to run (`runAt: 'start'` is unlikely to work)
+
+If available, the `webNavigation` API will be automatically used in every situation for better performance.
+
 ## Related
 
 ### Permissions


### PR DESCRIPTION
Fixes #16 

Depends on https://github.com/fregante/content-scripts-register-polyfill/pull/18

- [x] Test in PixieBrix
- [x] Add documentation 