### PR TITLE
When a new origin is added, inject into existing tabs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ string,
 Promise<browser.contentScripts.RegisteredContentScript>
 >();
 
-type ContentScript = NonNullable<chrome.runtime.Manifest['content_scripts']>[number];
+type ContentScripts = NonNullable<chrome.runtime.Manifest['content_scripts']>;
 
 // In Firefox, paths in the manifest are converted to full URLs under `moz-extension://` but browser.contentScripts expects exclusively relative paths
 function convertPath(file: string): browser.extensionTypes.ExtensionFileOrCode {
@@ -14,7 +14,7 @@ function convertPath(file: string): browser.extensionTypes.ExtensionFileOrCode {
 	return {file: url.pathname};
 }
 
-function injectIntoTab(tabId: number, scripts: ContentScript[]) {
+function injectIntoTab(tabId: number, scripts: ContentScripts) {
 	for (const script of scripts) {
 		for (const file of script.css || []) {
 			void chrome.tabs.insertCSS(tabId, {
@@ -32,7 +32,7 @@ function injectIntoTab(tabId: number, scripts: ContentScript[]) {
 	}
 }
 
-function injectOnExistingTabs(origins: string[], scripts: ContentScript[]) {
+function injectOnExistingTabs(origins: string[], scripts: ContentScripts) {
 	chrome.tabs.query({
 		url: origins
 	}, tabs => {

--- a/index.ts
+++ b/index.ts
@@ -6,10 +6,42 @@ string,
 Promise<browser.contentScripts.RegisteredContentScript>
 >();
 
+type ContentScript = NonNullable<chrome.runtime.Manifest['content_scripts']>[number];
+
 // In Firefox, paths in the manifest are converted to full URLs under `moz-extension://` but browser.contentScripts expects exclusively relative paths
 function convertPath(file: string): browser.extensionTypes.ExtensionFileOrCode {
 	const url = new URL(file, location.origin);
 	return {file: url.pathname};
+}
+
+function injectIntoTab(tabId: number, scripts: ContentScript[]) {
+	for (const script of scripts) {
+		for (const file of script.css || []) {
+			void chrome.tabs.insertCSS(tabId, {
+				file,
+				allFrames: script.all_frames
+			});
+		}
+
+		for (const file of script.js || []) {
+			void chrome.tabs.executeScript(tabId, {
+				file,
+				allFrames: script.all_frames
+			});
+		}
+	}
+}
+
+function injectOnExistingTabs(origins: string[], scripts: ContentScript[]) {
+	chrome.tabs.query({
+		url: origins
+	}, tabs => {
+		for (const tab of tabs) {
+			if (tab.id) {
+				injectIntoTab(tab.id, scripts);
+			}
+		}
+	});
 }
 
 // Automatically register the content scripts on the new origins
@@ -35,6 +67,8 @@ async function registerOnOrigins({
 			registeredScripts.set(origin, registeredScript);
 		}
 	}
+
+	injectOnExistingTabs(newOrigins || [], manifest);
 }
 
 (async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webext-dynamic-content-scripts",
-	"version": "7.2.0-0",
+	"version": "8.0.0-1",
 	"description": "WebExtension module: Automatically registers your `content_scripts` on domains added via `permission.request`",
 	"keywords": [
 		"contentscript",


### PR DESCRIPTION
Replaces https://github.com/fregante/content-scripts-register-polyfill/pull/27

Due to a limitation/bug of the underlying API, contentScript.register(), content scripts have to be manually injected into any tabs that exist when a new origin is added.

- [x] Manually test
- [ ] Document — actually I don’t think this needs to be documented
