### PR TITLE
Avoid injecting scripts on every tab on start

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,10 @@ function injectIntoTab(tabId: number, scripts: ContentScripts) {
 }
 
 function injectOnExistingTabs(origins: string[], scripts: ContentScripts) {
+	if (origins.length === 0) {
+		return;
+	}
+
 	chrome.tabs.query({
 		url: origins,
 	}, tabs => {


### PR DESCRIPTION
`chrome.tabs.query({url: []})` return every tab instead of returning none, so if no tabs were currently open it would try to inject it in _all_ of them.