### PR TITLE
Avoid duplicate injections when using `persistent: false`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,13 +80,13 @@ async function registerOnOrigins({
 	injectOnExistingTabs(newOrigins || [], manifest);
 }
 
-(async () => {
+chrome.runtime.onStartup.addListener(async () => {
 	void registerOnOrigins(
 		await getAdditionalPermissions({
 			strictOrigins: false,
 		}),
 	);
-})();
+});
 
 chrome.permissions.onAdded.addListener(permissions => {
 	if (permissions.origins && permissions.origins.length > 0) {


### PR DESCRIPTION
- Fixes https://github.com/fregante/content-scripts-register-polyfill/issues/48
- Will fix https://github.com/refined-github/refined-github/issues/4827