### PR TITLE
Support event pages (`persistent: false`)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,13 +65,13 @@ async function registerOnOrigins({
 	injectToExistingTabs(newOrigins || [], manifest);
 }
 
-(async () => {
-	void registerOnOrigins(
+chrome.runtime.onStartup.addListener(async () =>
+	registerOnOrigins(
 		await getAdditionalPermissions({
 			strictOrigins: false,
 		}),
-	);
-})();
+	),
+);
 
 chrome.permissions.onAdded.addListener(permissions => {
 	if (permissions.origins && permissions.origins.length > 0) {


### PR DESCRIPTION
- Fix for https://github.com/fregante/content-scripts-register-polyfill/issues/48

But this appears to break the tests 😰 