### PR TITLE
Update dependencies + increase minimum browser version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ async function registerContentScript(
 				id,
 				...contentScript,
 			}]);
-		} catch (error: unknown) {
+		} catch (error) {
 			if (!(error as Error)?.message.startsWith('Duplicate script ID')) {
 				throw error;
 			}

--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -1,5 +1,5 @@
-const path = require('path');
-const process = require('process');
+const path = require('node:path');
+const process = require('node:process');
 
 module.exports = {
 	launch: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,19 @@
 			"dependencies": {
 				"content-scripts-register-polyfill": "^3.2.2",
 				"webext-additional-permissions": "^2.3.0",
-				"webext-content-scripts": "^1.0.2"
+				"webext-content-scripts": "^1.0.3"
 			},
 			"devDependencies": {
-				"@parcel/config-webextension": "^2.6.0",
+				"@parcel/config-webextension": "^2.8.0",
 				"@sindresorhus/tsconfig": "^3.0.1",
-				"@types/chrome": "^0.0.190",
+				"@types/chrome": "^0.0.203",
 				"@types/firefox-webext-browser": "^94.0.1",
 				"jest": "^28.1.1",
 				"jest-puppeteer": "^6.1.0",
-				"parcel": "^2.6.0",
+				"parcel": "^2.8.0",
 				"puppeteer": "^14.4.0",
-				"typescript": "^4.7.3",
-				"xo": "^0.50.0"
+				"typescript": "^4.9.3",
+				"xo": "^0.53.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
@@ -256,9 +256,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -610,14 +610,14 @@
 			"dev": true
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"globals": "^13.15.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -627,6 +627,9 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/argparse": {
@@ -663,17 +666,30 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.9.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+			"version": "0.11.7",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
@@ -1081,6 +1097,84 @@
 				"@lezer/common": "^0.15.0"
 			}
 		},
+		"node_modules/@lmdb/lmdb-darwin-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+			"integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lmdb/lmdb-darwin-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+			"integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-arm": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+			"integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+			"integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lmdb/lmdb-linux-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+			"integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lmdb/lmdb-win32-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+			"integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@mischnic/json-sourcemap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -1209,20 +1303,21 @@
 			}
 		},
 		"node_modules/@parcel/bundler-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.0.tgz",
-			"integrity": "sha512-AplEdGm/odV7yGmoeOnglxnY31WlNB5EqGLFGxkgs7uwDaTWoTX/9SWPG6xfvirhjDpms8sLSiVuBdFRCCLtNA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.0.tgz",
+			"integrity": "sha512-OvDDhxX4LwfGe7lYVMbJMzqNcDk8ydOqNw0Hra9WPgl0m5gju/eVIbDvot3JXp5F96FmV36uCxdODJhKTNoAzQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/graph": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1230,15 +1325,15 @@
 			}
 		},
 		"node_modules/@parcel/cache": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.0.tgz",
-			"integrity": "sha512-4vbD5uSuf+kRnrFesKhpn0AKnOw8u2UlvCyrplYmp1g9bNAkIooC/nDGdmkb/9SviPEbni9PEanQEHDU2+slpA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.0.tgz",
+			"integrity": "sha512-k945hrafMDR2wyCKyZYgwypeLLuZWce6FzhgunI4taBUeVnNCcpFAWzbfOVQ39SqZTGDqG3MNT+VuehssHXxyg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"lmdb": "2.3.10"
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"lmdb": "2.5.2"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
@@ -1248,13 +1343,13 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/codeframe": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.0.tgz",
-			"integrity": "sha512-yXXxrO9yyedHKpTwC+Af0+vPmQm+A9xeEhkt4f0yVg1n4t4yUIxYlTedzbM8ygZEEBtkXU9jJ+PkgXbfMf0dqw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.0.tgz",
+			"integrity": "sha512-821d+KVcpEvJNMj9WMC39xXZK6zvRS/HUjQag2f3DkcRcZwk1uXJZdW6p1EB7C3e4e/0KSK3NTSVGEvbOSR+9w==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0"
@@ -1268,16 +1363,16 @@
 			}
 		},
 		"node_modules/@parcel/compressor-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.0.tgz",
-			"integrity": "sha512-rtMU2mGl88bic6Xbq1u5L49bMK4s5185b0k7h3JRdS6/0rR+Xp4k/o9Wog+hHjK/s82z1eF9WmET779ZpIDIQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.0.tgz",
+			"integrity": "sha512-tM49t0gDQnwJbrDCeoCn9LRc8inZ/TSPQTttJTfcmFHHFqEllI0ZDVG0AiQw5NOMQbBLYiKun1adXn8pkcPLEA==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1285,90 +1380,90 @@
 			}
 		},
 		"node_modules/@parcel/config-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.0.tgz",
-			"integrity": "sha512-DXovFPhZITmTvFaSEdC8RRqROs9FLIJ4u8yFSU6FUyq2wpvtYVRXXoDrvXgClh2csXmK7JTJTp5JF7r0rd2UaA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.0.tgz",
+			"integrity": "sha512-j9g50QNSLjuNpY0TP01EgGJPxWNes9d+e8+N07Z5Wv0u+UUnJ2uIOpo7PVn7ullOGhm1f9lP4KsJenu5gWb+cg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/bundler-default": "2.6.0",
-				"@parcel/compressor-raw": "2.6.0",
-				"@parcel/namer-default": "2.6.0",
-				"@parcel/optimizer-css": "2.6.0",
-				"@parcel/optimizer-htmlnano": "2.6.0",
-				"@parcel/optimizer-image": "2.6.0",
-				"@parcel/optimizer-svgo": "2.6.0",
-				"@parcel/optimizer-terser": "2.6.0",
-				"@parcel/packager-css": "2.6.0",
-				"@parcel/packager-html": "2.6.0",
-				"@parcel/packager-js": "2.6.0",
-				"@parcel/packager-raw": "2.6.0",
-				"@parcel/packager-svg": "2.6.0",
-				"@parcel/reporter-dev-server": "2.6.0",
-				"@parcel/resolver-default": "2.6.0",
-				"@parcel/runtime-browser-hmr": "2.6.0",
-				"@parcel/runtime-js": "2.6.0",
-				"@parcel/runtime-react-refresh": "2.6.0",
-				"@parcel/runtime-service-worker": "2.6.0",
-				"@parcel/transformer-babel": "2.6.0",
-				"@parcel/transformer-css": "2.6.0",
-				"@parcel/transformer-html": "2.6.0",
-				"@parcel/transformer-image": "2.6.0",
-				"@parcel/transformer-js": "2.6.0",
-				"@parcel/transformer-json": "2.6.0",
-				"@parcel/transformer-postcss": "2.6.0",
-				"@parcel/transformer-posthtml": "2.6.0",
-				"@parcel/transformer-raw": "2.6.0",
-				"@parcel/transformer-react-refresh-wrap": "2.6.0",
-				"@parcel/transformer-svg": "2.6.0"
+				"@parcel/bundler-default": "2.8.0",
+				"@parcel/compressor-raw": "2.8.0",
+				"@parcel/namer-default": "2.8.0",
+				"@parcel/optimizer-css": "2.8.0",
+				"@parcel/optimizer-htmlnano": "2.8.0",
+				"@parcel/optimizer-image": "2.8.0",
+				"@parcel/optimizer-svgo": "2.8.0",
+				"@parcel/optimizer-terser": "2.8.0",
+				"@parcel/packager-css": "2.8.0",
+				"@parcel/packager-html": "2.8.0",
+				"@parcel/packager-js": "2.8.0",
+				"@parcel/packager-raw": "2.8.0",
+				"@parcel/packager-svg": "2.8.0",
+				"@parcel/reporter-dev-server": "2.8.0",
+				"@parcel/resolver-default": "2.8.0",
+				"@parcel/runtime-browser-hmr": "2.8.0",
+				"@parcel/runtime-js": "2.8.0",
+				"@parcel/runtime-react-refresh": "2.8.0",
+				"@parcel/runtime-service-worker": "2.8.0",
+				"@parcel/transformer-babel": "2.8.0",
+				"@parcel/transformer-css": "2.8.0",
+				"@parcel/transformer-html": "2.8.0",
+				"@parcel/transformer-image": "2.8.0",
+				"@parcel/transformer-js": "2.8.0",
+				"@parcel/transformer-json": "2.8.0",
+				"@parcel/transformer-postcss": "2.8.0",
+				"@parcel/transformer-posthtml": "2.8.0",
+				"@parcel/transformer-raw": "2.8.0",
+				"@parcel/transformer-react-refresh-wrap": "2.8.0",
+				"@parcel/transformer-svg": "2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/config-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.6.0.tgz",
-			"integrity": "sha512-CjFo5gnFgwIlF+kt89jRrf4yHMb56sgyE/h9o0hBmg5UaptvR7iTRcp3c9J0dqRF09BaPdsN6clOGthKZW/jlw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.8.0.tgz",
+			"integrity": "sha512-80gtgNU77kT1DY9SXNt8CwBgHLu5qWwmo0sw2SCMzg+iXYSj8WAuESAN56O6J+Su3IWs+IzF6MdCAYFTyGM5mA==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/config-default": "2.6.0",
-				"@parcel/packager-webextension": "2.6.0",
-				"@parcel/runtime-webextension": "2.6.0",
-				"@parcel/transformer-raw": "2.6.0",
-				"@parcel/transformer-webextension": "2.6.0"
+				"@parcel/config-default": "2.8.0",
+				"@parcel/packager-webextension": "2.8.0",
+				"@parcel/runtime-webextension": "2.8.0",
+				"@parcel/transformer-raw": "2.8.0",
+				"@parcel/transformer-webextension": "2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.0.tgz",
-			"integrity": "sha512-8OOWbPuxpFydpwNyKoz6d3e3O4DmxNYmMw4DXwrPSj/jyg7oa+SDtMT0/VXEhujE0HYkQPCHt4npRajkSuf99A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
+			"integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
 			"dev": true,
 			"dependencies": {
 				"@mischnic/json-sourcemap": "^0.1.0",
-				"@parcel/cache": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/graph": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/cache": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/graph": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"abortcontroller-polyfill": "^1.1.9",
 				"base-x": "^3.0.8",
 				"browserslist": "^4.6.6",
@@ -1388,196 +1483,10 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/css": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.10.0.tgz",
-			"integrity": "sha512-YvlUqJ3kg/HxsVvq02bTCGruQKjwPEMWEqdyhgfR3aagt+1ibmafy3m8CGYHXvhaQeNYSkMvy1D9bcddFuYTUg==",
-			"dev": true,
-			"dependencies": {
-				"detect-libc": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"@parcel/css-darwin-arm64": "1.10.0",
-				"@parcel/css-darwin-x64": "1.10.0",
-				"@parcel/css-linux-arm-gnueabihf": "1.10.0",
-				"@parcel/css-linux-arm64-gnu": "1.10.0",
-				"@parcel/css-linux-arm64-musl": "1.10.0",
-				"@parcel/css-linux-x64-gnu": "1.10.0",
-				"@parcel/css-linux-x64-musl": "1.10.0",
-				"@parcel/css-win32-x64-msvc": "1.10.0"
-			}
-		},
-		"node_modules/@parcel/css-darwin-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.10.0.tgz",
-			"integrity": "sha512-WMAbjUyCBrXwv3OofNk90K+G0DqZgCFRtKCg+udLXLZCiCe6yrI87ye9SC6KAVwqWp5WT27TPZTrqWJ032e3FA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-darwin-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.10.0.tgz",
-			"integrity": "sha512-p1JJVHOOxrhcSQMq9qlrU88Sl+VJGu8HXBpWDHRzh8aOIkqsiRx1qx9Vl3zGX7Sxnjv/xlPUknLKia8Zy1369A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-linux-arm-gnueabihf": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.10.0.tgz",
-			"integrity": "sha512-cUvDN+nNEdoEzZLhOqPAcjICIyEGcFCc0+zJhGKdnA9MC010aeun9ggtToFazIHzMmoF4qyxCY5IyHja8iVkmA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-linux-arm64-gnu": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.10.0.tgz",
-			"integrity": "sha512-x8XEtJxgJlstAwbg1BLeYuXhUXEOxGg/BeBFPZr8Zk8dNQ1j1jR7LBk12IKgZrvr+Px1WOFY65lwabgCyFqxnQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-linux-arm64-musl": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.10.0.tgz",
-			"integrity": "sha512-caBaOM+zhFYlaMB2GL327NeOkF5lbHte5XLrGByagLWanlnRRlFpapIXpuuGIGSF5uBHN2uAz/84ej5mNcdHwg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-linux-x64-gnu": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.10.0.tgz",
-			"integrity": "sha512-9JZUMB1v+Zh95K2BJdoC20vZcObqF3mPA10gM51/a44f3rhRsv/EHjzLsSqxSYtC+L7wLvW9M3SNZ2KTo0J2/A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-linux-x64-musl": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.10.0.tgz",
-			"integrity": "sha512-U702L0HlZUN5Fxb6jbDetYeA7eOgLHkXo4vZ9/XHJyPy6jD+n+9HO8bEcLdSAadJcb4Ndcn89THyfwKiOHukVQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/css-win32-x64-msvc": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.10.0.tgz",
-			"integrity": "sha512-44GtojxQBRf8yTetsNdjYSa2KL4/UpSbEeaOYcO+PKBGHcCyQX2Lex5r1X2pXkpNxvu142+dSTLeXhBSFG4C0g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/diagnostic": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.0.tgz",
-			"integrity": "sha512-+p8gC2FKxSI2veD7SoaNlP572v4kw+nafCQEPDtJuzYYRqywYUGncch25dkpgNApB4W4cXVkZu3ZbtIpCAmjQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.0.tgz",
+			"integrity": "sha512-ERnk0zDvm0jQUSj1M+2PLiwVC6nWrtuFEuye6VGuxRDcp9NHbz6gwApeEYxFkPsb3TQPhNjnXXm5nmAw1bpWWw==",
 			"dev": true,
 			"dependencies": {
 				"@mischnic/json-sourcemap": "^0.1.0",
@@ -1592,9 +1501,9 @@
 			}
 		},
 		"node_modules/@parcel/events": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.0.tgz",
-			"integrity": "sha512-2WaKtBs4iYwS88j4zRdyTJTgh8iuY4E32FMmjzzbheqETs6I05gWuPReGukJYxk8vc0Ir7tbzp12oAfpgo0Y+g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.0.tgz",
+			"integrity": "sha512-xqSZYY3oONM4IZm9+vhyFqX+KFIl145veIczUikwGJlcJZQfAAw736syPx6ecpB+m1EVg3AlvJWy7Lmel4Ak+Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.0.0"
@@ -1605,16 +1514,16 @@
 			}
 		},
 		"node_modules/@parcel/fs": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.0.tgz",
-			"integrity": "sha512-6vxtx5Zy6MvDvH1EPx9JxjKGF03bR7VE1dUf4HLeX2D8YmpL5hkHJnlRCFdcH08rzOVwaJLzg1QNtblWJXQ9CA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.0.tgz",
+			"integrity": "sha512-v3DbJlpl8v2/VRlZPw7cy+0myi0YfLblGZcwDvqIsWS35qyxD2rmtYV8u1BusonbgmJeaKiopSECmJkumt0jCw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/fs-search": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/watcher": "^2.0.0",
-				"@parcel/workers": "2.6.0"
+				"@parcel/fs-search": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/watcher": "^2.0.7",
+				"@parcel/workers": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
@@ -1624,13 +1533,13 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/fs-search": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.0.tgz",
-			"integrity": "sha512-1nXzM3H/cA4kzLKvDBvwmNisKCdRqlgkLXh+OR1Zu28Kn4W34KuJMcHWW8cC+WIuuKqDh5oo2WPsC5y65GXBKQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.0.tgz",
+			"integrity": "sha512-yo7/Y8DCFlhOlIBb5SsRDTkM+7g0DY9sK57iw3hn2z1tGoIiIRptrieImFYSizs7HfDwDY/PMLfORmUdoReDzQ==",
 			"dev": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3"
@@ -1644,12 +1553,12 @@
 			}
 		},
 		"node_modules/@parcel/graph": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.0.tgz",
-			"integrity": "sha512-rxrAzWm6rwbCRPbu0Z+zwMscpG8omffODniVWPlX2G0jgQGpjKsutBQ6RMfFIcfaQ4MzL3pIQOTf8bkjQOPsbg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.0.tgz",
+			"integrity": "sha512-JvAyvBpGmhZ30bi+hStQr52eu+InfJBoiN9Z/32byIWhXEl02EAOwfsPqAe+FGCsdgXnnCGg5F9ZCqwzZ9dwbw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/utils": "2.6.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
@@ -1661,9 +1570,9 @@
 			}
 		},
 		"node_modules/@parcel/hash": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.0.tgz",
-			"integrity": "sha512-YugWqhLxqK80Lo++3B3Kr5UPCHOdS8iI2zJ1jkzUeH9v6WUzbwWOnmPf6lN2S5m1BrIFFJd8Jc+CbEXWi8zoJA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.0.tgz",
+			"integrity": "sha512-KV1+96t7Nukth5K7ldUXjVr8ZTH9Dohl49K0Tc+5Qkysif0OxwcDtpVDmcnrUnWmqdBX0AdoLY0Q2Nnly89n/w==",
 			"dev": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3",
@@ -1678,13 +1587,13 @@
 			}
 		},
 		"node_modules/@parcel/logger": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.0.tgz",
-			"integrity": "sha512-J1/7kPfSGBvMKSZdi0WCNuN0fIeiWxifnDGn7W/K8KhD422YwFJA8N046ps8nkDOPIXf1osnIECNp4GIR9oSYw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.0.tgz",
+			"integrity": "sha512-W+7rKsLxLUX6xRmP8PhGWcG48PqrzTPeMWpgSds5nXxAHEFh4cYbkwPKGoTU65a9xUDVyqNreHNIKyizgwAZHQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0"
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
@@ -1695,9 +1604,9 @@
 			}
 		},
 		"node_modules/@parcel/markdown-ansi": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.0.tgz",
-			"integrity": "sha512-fyjkrJQQSfKTUFTTasdZ6WrAkDoQ2+DYDjj+3p+RncYyrIa9zArKx4IiRiipsvNdtMvP0/hTdK8F3BOJ3KSU/g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.0.tgz",
+			"integrity": "sha512-xItzXmc3btFhJXsIbE946iaqE6STd2xe5H0zSIaZVXEeucCtMzcd4hxRELquxPstlrAOrrp/lrRpbAlMhso9iA==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0"
@@ -1711,18 +1620,18 @@
 			}
 		},
 		"node_modules/@parcel/namer-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-			"integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.0.tgz",
+			"integrity": "sha512-cVCx2kJA/Bv7O9pVad1UOibaybR/B+QdWV8Ols8HH4lC2gyjLBXEIR0uuPSEbkGwMEcofG6zA3MwsoPa6r5lBg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1730,14 +1639,15 @@
 			}
 		},
 		"node_modules/@parcel/node-resolver-core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.0.tgz",
-			"integrity": "sha512-AJDj5DZbB58plv0li8bdVSD+zpnkHE36Om3TYyNn1jgXXwgBM64Er/9p8yQn356jBqTQMh7zlJqvbdIyOiMeMg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.0.tgz",
+			"integrity": "sha512-cECSh08NSRt1csmmMeKxlnO6ZhXRTuRijkHKFa4iG5hPL+3Cu04YGhuK/QWlP5vNCPVrH3ISlhzlPU5fAi/nEg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"nullthrows": "^1.1.1"
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"nullthrows": "^1.1.1",
+				"semver": "^5.7.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
@@ -1748,22 +1658,22 @@
 			}
 		},
 		"node_modules/@parcel/optimizer-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.0.tgz",
-			"integrity": "sha512-VMJknUwfKCw6Woov0lnPGdsGZewcI4ghW8WKmNZzC5uKCetk1XetV55QHBc1RNjGfsjfSTZiSa3guATj2zFJkQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.0.tgz",
+			"integrity": "sha512-T5r3gZVm1xFw6l//iLkzLDUvFzNTUvL5kAtyU5gS5yH/dg7eCS09Km/c2anViQnmXwFUt7zIlBovj1doxAVNSw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/css": "^1.9.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
+				"lightningcss": "^1.16.1",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1771,12 +1681,12 @@
 			}
 		},
 		"node_modules/@parcel/optimizer-htmlnano": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.0.tgz",
-			"integrity": "sha512-HmvcUoYpfdx8ZfID4WOj/SE8N78NEBmzAffZ8f827mYMr4ZrbKzAgg6OG3tBbfF0zxH0bIjZcwqwZYk4SdbG7g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.0.tgz",
+			"integrity": "sha512-NxEKTRvue/WAU+XbQGfNIU6c7chDekdkwwv9YnCxHEOhnBu4Ok+2tdmCtPuA+4UUNszGxXlaHMnqSrjmqX2S6Q==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
+				"@parcel/plugin": "2.8.0",
 				"htmlnano": "^2.0.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
@@ -1784,7 +1694,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1792,20 +1702,20 @@
 			}
 		},
 		"node_modules/@parcel/optimizer-image": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.0.tgz",
-			"integrity": "sha512-FDNr3LJ8SWR9rrtdCrZOlYF1hE9G5pxUWawGxUasbvqwcY5lEQwr2KRmfGZeg+KwOnzlImlY6dP2LGox1NFddQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.0.tgz",
+			"integrity": "sha512-66eSoCCGZVRiY6U4OqqYrhQcBcHI9cOkIEbxadZYOF4cJhsskjUDJR0jLb4j2PE6QxUNYlyj5OglQqRLwhz7vA==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"detect-libc": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1813,19 +1723,19 @@
 			}
 		},
 		"node_modules/@parcel/optimizer-svgo": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.0.tgz",
-			"integrity": "sha512-LMTDVMd7T/IfLG59yLWl8Uw2HYGbj2C3jIwkMqH9MBUT5KILK66T3t0yV86SoZJnxZ6xBIJ+kCcCRssCzhvanw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.0.tgz",
+			"integrity": "sha512-qQzM32CzJJuniFaTZDspVn/Vtz/PJ/f89+FckLpWZJVWNihgwTHC1/F0YTDH8g6czNw5ZijwQ3xBVuJQYyIXsQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"svgo": "^2.4.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1833,21 +1743,21 @@
 			}
 		},
 		"node_modules/@parcel/optimizer-terser": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.0.tgz",
-			"integrity": "sha512-oezRt6Lz/QqcVDXyMfFjzQc7n0ThJowLJ4Lyhu8rMh0ZJYzc4UCFCw/19d4nRnzE+Qg0vj3mQCpdkA9/64E44g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.0.tgz",
+			"integrity": "sha512-slS6GWQ3u418WtJmlqlA5Njljcq4OaEdDDR2ifEwltG8POv+hsvD5AAoM2XB0GJwY97TQtdMbBu2DuDF3yM/1Q==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"terser": "^5.2.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1855,17 +1765,17 @@
 			}
 		},
 		"node_modules/@parcel/package-manager": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.0.tgz",
-			"integrity": "sha512-AqFfdkbOw51q/3ia2mIsFTmrpYEyUb3k+2uYC5GsLMz3go6OGn7/Crz0lZLSclv5EtwpRg3TWr9yL7RekVN/Uw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.0.tgz",
+			"integrity": "sha512-n4FgerAX1lTKKTgxmiocnos47Y+b0L60iwU6Q4cC2n4KQNRuNyfhxFXwWcqHstR9wa72JgPaDgo4k0l3Bk8FZw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"semver": "^5.7.1"
 			},
 			"engines": {
@@ -1876,23 +1786,23 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/packager-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.0.tgz",
-			"integrity": "sha512-iXUttSe+wtnIM2PKCyFC2I4+Szv+8qHpC3wXeJlXlzd8wljm42y+6Fs4FZ0zihTccRxI2UUhFnKu90ag+5AmjA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.0.tgz",
+			"integrity": "sha512-tv/Bto0P6fXjqQ9uCZ8/6b/+38Zr/N2MC7/Nbflzww/lp0k2+kkE9MVJJDr5kST/SzTBRrhbDo+yTbtdZikJYg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1900,20 +1810,20 @@
 			}
 		},
 		"node_modules/@parcel/packager-html": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.0.tgz",
-			"integrity": "sha512-HsiXMkU9AJr3LLjsP2Kteho2jCVpabTwcU/fauwbwirhg0xNlRsKxYZRCllRhPkb0FWAnkjzwjOj01MHD6NJCg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.0.tgz",
+			"integrity": "sha512-4x09v/bt767rxwGTuEw82CjheoOtIKNu4sx1gqwQOz9QowKPniXOIaD+0XmLiARdzRErucf0sL19QHfNcPAhUw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1921,22 +1831,22 @@
 			}
 		},
 		"node_modules/@parcel/packager-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.0.tgz",
-			"integrity": "sha512-Uz3pqIFchFfKszWnNGDgIwM1uwHHJp7Dts6VzS9lf/2RbRgZT0fmce+NPgnVO5MMKBHzdvm32ShT6gFAABF5Vw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.0.tgz",
+			"integrity": "sha512-Tn2EtWM1TEdj4t5pt0QjBDzqrXrfRTL3WsdMipZwDSuX04KS0jedJINHjh46HOMwyfJxLbUg3xkGX7F5mYQj5g==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"globals": "^13.2.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1944,16 +1854,16 @@
 			}
 		},
 		"node_modules/@parcel/packager-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.0.tgz",
-			"integrity": "sha512-ktT6Qc/GgCq8H1+6y+AXufVzQj1s6KRoKf83qswCD0iY3MwCbJoEfc3IsB4K64FpHIL5Eu0z54IId+INvGbOYA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.0.tgz",
+			"integrity": "sha512-s3VniER3X2oNTlfytBGIQF+UZFVNLFWuVu1IkZ8Wg6uYQffrExDlbNDcmFCDcfvcejL3Ch5igP+L6N00f6+wAQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1961,19 +1871,19 @@
 			}
 		},
 		"node_modules/@parcel/packager-svg": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.0.tgz",
-			"integrity": "sha512-OF2RShyspXu7H4Dn2PmchfMMYPx+kWjOXiYVQ6OkOI0MZmOydx7p8nrcG5+y7vCJTPlta828BSwva0GdKfn46A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.0.tgz",
+			"integrity": "sha512-+BSpdPiNjlAne28nOjG2AyiOejAehe/+X9MxL2FIpPP7UBLNc2ekaM0mDTR5iY45YtZa57oyErBT/U6wZ1TCjw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"posthtml": "^0.16.4"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1981,18 +1891,18 @@
 			}
 		},
 		"node_modules/@parcel/packager-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.6.0.tgz",
-			"integrity": "sha512-tXFamEXJXbp6NuVD/SdPLrHj8UqWfGaMgtZGo5dvQp2eyxcjfyKMPS4iZWf8H6tlJPbBK+m26AaSs0QKXMxUuw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.8.0.tgz",
+			"integrity": "sha512-ODB3sTXk/qyivK0JcM+kw9MV5pWigqppIOXQAK5zPv4sYHlMNuZJiANKizs5aP1+9Iz5ludU1wM1qMe1n/xDiw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2000,12 +1910,12 @@
 			}
 		},
 		"node_modules/@parcel/plugin": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.0.tgz",
-			"integrity": "sha512-LzOaiK8R6eFEoov1cb3/W+o0XvXdI/VbDhMDl0L0II+/56M0UeayYtFP5QGTDn/fZqVlYfzPCtt3EMwdG7/dow==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.0.tgz",
+			"integrity": "sha512-Tsf+7nDg7KauvTVY6rGc7CmgJruKSwJ54KJ9s5nYFFP9nfwmyqbayCi9xOxicWU9zIHfuF5Etwf17lcA0oAvzw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/types": "2.6.0"
+				"@parcel/types": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
@@ -2016,20 +1926,20 @@
 			}
 		},
 		"node_modules/@parcel/reporter-cli": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.0.tgz",
-			"integrity": "sha512-QFG957NXx3L0D8Zw0+B2j7IHy8f/UzOVu6VvKE3rMkhq/iR2qLrPohQ+uvxlee+CLC0cG2qRSgJ7Ve/rjQPoJg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.0.tgz",
+			"integrity": "sha512-ea4/Lp+2jDbzb/tfTgUKzYU51FK8wcewDoYNr06uL+wvx/vzYIDG0jHfzaOTasREnm7ECDr1Zu2Iknrgk1STqQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chalk": "^4.1.0",
 				"term-size": "^2.2.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2037,17 +1947,17 @@
 			}
 		},
 		"node_modules/@parcel/reporter-dev-server": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.0.tgz",
-			"integrity": "sha512-VvygsCA+uzWyijIV8zqU1gFyhAWknuaY4KIWhV4kCT8afRJwsLSwt/tpdaKDPuPU45h3tTsUdXH1wjaIk+dGeQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.0.tgz",
+			"integrity": "sha512-wg6hUrQ8vUmvlP2fg8YEzYndmq7hWZ21ZgBv4So1Z65I+Qav85Uox7bjGLCSJwEAjdjFKfhV9RGULGzqh8vcAQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0"
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2055,17 +1965,17 @@
 			}
 		},
 		"node_modules/@parcel/resolver-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.0.tgz",
-			"integrity": "sha512-ATk9wXvy5GOHAqyHbnCnU11fUPTtf8dLjpgVqL5XylwugZnyBXbynoTWX4w8h6mffkVtdfmzTJx/o4Lresz9sA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.0.tgz",
+			"integrity": "sha512-kO5W+O3Ql6NXNFS6lvfSSt1R+PxO1atNLYxZdVSM6+QQxRMiztfqzZs//RM+oUp+af6muDSUPlNs+RORX0fing==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/node-resolver-core": "2.6.0",
-				"@parcel/plugin": "2.6.0"
+				"@parcel/node-resolver-core": "2.8.0",
+				"@parcel/plugin": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2073,17 +1983,17 @@
 			}
 		},
 		"node_modules/@parcel/runtime-browser-hmr": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.0.tgz",
-			"integrity": "sha512-90xvv/10cFML5dAhClBEJZ/ExiBQVPqQsZcvRmVZmc5mpZVJMKattWCQrd7pAf7FDYl4JAcvsK3DTwvRT/oLNA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.0.tgz",
+			"integrity": "sha512-zV5wGGvm1cDwWAzkwPUaKh6inWYKxq67YWY4G396PXLMxddM9SQC1c7iFM60OPnD4A+BMOLOy7N6//20h15Dlg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0"
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2091,18 +2001,18 @@
 			}
 		},
 		"node_modules/@parcel/runtime-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.0.tgz",
-			"integrity": "sha512-R4tJAIT/SX7VBQ+f7WmeekREQzzLsmgP1j486uKhQNyYrpvsN0HnRbg5aqvZjEjkEmSeJR0mOlWtMK5/m+0yTA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.0.tgz",
+			"integrity": "sha512-IwT1rX8ZamoYZv0clfswZemfXcIfk+YXwNsqXwzzh6TaMGagj/ZZl1llkn7ERQFq4EoLEoDGGkxqsrJjBp9NDQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2110,19 +2020,19 @@
 			}
 		},
 		"node_modules/@parcel/runtime-react-refresh": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.0.tgz",
-			"integrity": "sha512-2sRd13gc2EbMV/O5n2NPVGGhKBasb1fDTXGEY8y7qi9xDKc+ewok/D83T+w243FhCPS9Pf3ur5GkbPlrJGcenQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.0.tgz",
+			"integrity": "sha512-a6uuZWkl+mJur2WLZKmpEqq1P06tvRwqGefYbE26DWpwXwU9dLpfnv/nT0hqCmVDHd2TkMyCffolSmq1vY05ew==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"react-error-overlay": "6.0.9",
 				"react-refresh": "^0.9.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2130,18 +2040,18 @@
 			}
 		},
 		"node_modules/@parcel/runtime-service-worker": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.0.tgz",
-			"integrity": "sha512-nVlknGw5J5Bkd1Wr1TbyWHhUd9CmVVebaRg/lpfVKYhAuE/2r+3N0+J8qbEIgtTRcHaSV7wTNpg4weSWq46VeA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.0.tgz",
+			"integrity": "sha512-Q3Q2O/axQbFi/5Z+BidLB3qhmYdZLTMDagZtsmyH7CktDkZVNV/0UoOGYlqoK06T4cww3XjLSEomXbBu9TlQKQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2149,18 +2059,18 @@
 			}
 		},
 		"node_modules/@parcel/runtime-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.6.0.tgz",
-			"integrity": "sha512-FKdWsSwFktRP1nZxhJwDOmIiEEjVNWk4a96TSC+0baU7IYVHhUZzBu9EtwJdyoJYQr5jyNP2SW3YUrkFFbCYiQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.8.0.tgz",
+			"integrity": "sha512-pfE30DHlw55GOTxp5k5NkCk2ccgJouF/JtCgHaAJdLqiEoqltsta6yFhHQj9ZLUV1qtjd5MxfIs5xOVXGp8SHw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2168,9 +2078,9 @@
 			}
 		},
 		"node_modules/@parcel/source-map": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-			"integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+			"integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
 			"dev": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3"
@@ -2180,15 +2090,15 @@
 			}
 		},
 		"node_modules/@parcel/transformer-babel": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.0.tgz",
-			"integrity": "sha512-qTDzhLoaTpRJoppCNqaAlcUYxcDEvJffem1h3SAQiwvCLUBQowLyeaBy8sUxu54AU6eHFJyBld5ZocENyHTBCA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.0.tgz",
+			"integrity": "sha512-ie+wFe9pucdnRyX2PTN9amOHrhr/IOwUEAfTz/3dPydOYCuX7ErEngCpI9fBzdYE2AV6/noEwC2Mjeoyz9mT2A==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
 				"json5": "^2.2.0",
 				"nullthrows": "^1.1.1",
@@ -2196,7 +2106,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2204,22 +2114,22 @@
 			}
 		},
 		"node_modules/@parcel/transformer-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.0.tgz",
-			"integrity": "sha512-Ei9NPE5Rl9V+MGd8qddfZD0Fsqbvky8J62RwYsqLkptFl9FkhgwOu8Cmokz7IIc4GJ2qzfnG5y54K/Bi7Moq4Q==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.0.tgz",
+			"integrity": "sha512-jCMQSfsxCoepblBAHCYMuNWNPQlqasoD6PfNftMdTlv12aUcnjNIYO9600TVLTL799CrEohljbXcfFn6hDGVWw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/css": "^1.9.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
+				"lightningcss": "^1.16.1",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2227,14 +2137,14 @@
 			}
 		},
 		"node_modules/@parcel/transformer-html": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.0.tgz",
-			"integrity": "sha512-YQh5WzNFjPhgV09P+zVS++albTCTvbPYAJXp5zUJ4HavzcpV2IB3HAPRk9x+iXUeRBQYYiO5SMMRkdy9a4CzQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.0.tgz",
+			"integrity": "sha512-KLcZCWSIItZ1s12Sav3uvfTrwhX92craN9u7V3qUs8ld7ompTKsCdnf+gYmeCyISb5yiFDyYBvTGc1bOXvaDRQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -2243,7 +2153,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2251,35 +2161,36 @@
 			}
 		},
 		"node_modules/@parcel/transformer-image": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.0.tgz",
-			"integrity": "sha512-Zkh1i6nWNOTOReKlZD+bLJCHA16dPLO6Or7ETAHtSF3iRzMNFcVFp+851Awj3l4zeJ6CoCWlyxsR4CEdioRgiQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.0.tgz",
+			"integrity": "sha512-hJGsZxGlGEkiUvN8kCxA4DhB6/WrHzcIlZZYEgEien9pLctyc6np6idjdcyudPAhH3LwBPkiyeUfCvLAOA1zkA==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/transformer-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.0.tgz",
-			"integrity": "sha512-4v2r3EVdMKowBziVBW9HZqvAv88HaeiezkWyMX4wAfplo9jBtWEp99KEQINzSEdbXROR81M9oJjlGF5+yoVr/w==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.0.tgz",
+			"integrity": "sha512-C5WTkDRiJGBB9tZa1mBsZwsqZjYEKkOa4mdVym3dMokwhFLUga8WtK7kGw4fmXIq41U8ip4orywj+Rd4mvGVWg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
-				"@swc/helpers": "^0.3.15",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
+				"@swc/helpers": "^0.4.12",
 				"browserslist": "^4.6.6",
 				"detect-libc": "^1.0.3",
 				"nullthrows": "^1.1.1",
@@ -2288,28 +2199,28 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@parcel/transformer-json": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.0.tgz",
-			"integrity": "sha512-zb+TQAdHWdXijKcFhLe+5KN1O0IzXwW1gJhPr8DJEA3qhPaCsncsw5RCVjQlP3a7NXr1mMm1eMtO6bhIMqbXeA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.0.tgz",
+			"integrity": "sha512-Pp5gROSMpzFDEI6KA2APuSpft6eXZxFgTPV6Xx9pElqseod3iL5+RnpMNV/nv76Ai2bcMEiafus5Pb09vjHgbQ==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
+				"@parcel/plugin": "2.8.0",
 				"json5": "^2.2.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2317,15 +2228,15 @@
 			}
 		},
 		"node_modules/@parcel/transformer-postcss": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.0.tgz",
-			"integrity": "sha512-czmh2mOPJLwYbtnPTFlxKYcaQHH6huIlpfNX1XgdsaEYS+yFs8ZXpzqjxI1wu6rMW0R0q5aon72yB3PJewvqNQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.0.tgz",
+			"integrity": "sha512-45Ij+cgwXprd1sCLmaMIlCbPz3eEwolGHizgZmXl5l4yjlE2wGyzodhxLpBk1PWu7OxxWRbLnJIlvMYf7Vfw0g==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"clone": "^2.1.1",
 				"nullthrows": "^1.1.1",
 				"postcss-value-parser": "^4.2.0",
@@ -2333,7 +2244,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2341,13 +2252,13 @@
 			}
 		},
 		"node_modules/@parcel/transformer-posthtml": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.0.tgz",
-			"integrity": "sha512-R1FmPMZ0pgrbPZkDppa2pE+6KDK3Wxof6uQo7juHLB2ELGOTaYofsG3nrRdk+chyAHaVv4qWLqXbfZK6pGepEg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.0.tgz",
+			"integrity": "sha512-KrkKBFDW5PNZpr2Ha711eIABQOiJQKvfwfVs3CVpJK5wSADkappDk7CQ0mISPjhamFJ6xx/sNsi7e871I8R9lg==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -2356,7 +2267,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2364,16 +2275,16 @@
 			}
 		},
 		"node_modules/@parcel/transformer-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.0.tgz",
-			"integrity": "sha512-QDirlWCS/qy0DQ3WvDIAnFP52n1TJW/uWH+4PGMNnX4/M3/2UchY8xp9CN0tx4NQ4g09S8o3gLlHvNxQqZxFrQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.0.tgz",
+			"integrity": "sha512-uEbj+kE70vg2Gmdji/AIXPK13s5aQRw7X+xWs3vNpY2oymyMRHbfx1izJFWBh+kxu6Yo6q6qsekkh2rNHEHIUA==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2381,18 +2292,18 @@
 			}
 		},
 		"node_modules/@parcel/transformer-react-refresh-wrap": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.0.tgz",
-			"integrity": "sha512-G34orfvLDUTumuerqNmA8T8NUHk+R0jwUjbVPO7gpB6VCVQ5ocTABdE9vN9Uu/cUsHij40TUFwqK4R9TFEBIEQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.0.tgz",
+			"integrity": "sha512-d7G6wBdlwVXLkhC7EO/3UkUOfEOJvsIsQUCEujsrdFF+nfBElXw/TZ+KP8UkmrwMdD0spU/8cKoTyi5k19vt6w==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"react-refresh": "^0.9.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2400,14 +2311,14 @@
 			}
 		},
 		"node_modules/@parcel/transformer-svg": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.0.tgz",
-			"integrity": "sha512-e7yrb7775A7tEGRsAHQSMhXe+u4yisH5W0PuIzAQQy/a2IwBjaSxNnvyelN7tNX0FYq0BK6An5wRbhK4YmM+xw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.0.tgz",
+			"integrity": "sha512-8S6yZoUTCbHOnuWY3M50fscTpI8414945I44fmed+C1e36TnWem8FifuVtGkRZeR8pokF453lmmwWG1eH/4U3w==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -2416,7 +2327,7 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0",
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2424,19 +2335,19 @@
 			}
 		},
 		"node_modules/@parcel/transformer-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.6.0.tgz",
-			"integrity": "sha512-Yp0Pwi/CPLBdK6joiDne0CEOCikfPkK+3VtL2AoCynvshwC4gZIXoR8jOKimvXfmNZTvZIN6WzpRN0ryGvpz2A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.8.0.tgz",
+			"integrity": "sha512-pGxATimkO7r8JbSysDD45YMmDvk4Tk2AHRQs5mLU/y7QwpT6d8zI30W4+ZpgDqx52Ih5BB2RlaGV1gZeLlpXqg==",
 			"dev": true,
 			"dependencies": {
 				"@mischnic/json-sourcemap": "^0.1.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"content-security-policy-parser": "^0.3.0"
 			},
 			"engines": {
-				"parcel": "^2.6.0"
+				"parcel": "^2.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2444,32 +2355,32 @@
 			}
 		},
 		"node_modules/@parcel/types": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.0.tgz",
-			"integrity": "sha512-lAMYvOBfNEJMsPJ+plbB50305o0TwNrY1xX5RRIWBqwOa6bYmbW1ZljUk1tQvnkpIE4eAHQwnPR5Z2XWg18wGQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.0.tgz",
+			"integrity": "sha512-DeN3vCnVl9onjtyWxpbP7LwRslVEko4kBaM7yILsuQjEnXmaIOsqIf6FQJOUOPBtQTFFNeQQ2qyf5XoO/rkJ8g==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/cache": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/cache": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/workers": "2.8.0",
 				"utility-types": "^3.10.0"
 			}
 		},
 		"node_modules/@parcel/utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.0.tgz",
-			"integrity": "sha512-ElXz+QHtT1JQIucbQJBk7SzAGoOlBp4yodEQVvTKS7GA+hEGrSP/cmibl6qm29Rjtd0zgQsdd+2XmP3xvP2gQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.0.tgz",
+			"integrity": "sha512-r4ACsGtW7zkMUIgwQyOVtPAFiy8L81gbz4tMIRSqyQKnkW7oEHcQ3uN1/LPxj2yfkyQLmhJxmtptLUy9j53rcw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/codeframe": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/markdown-ansi": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
+				"@parcel/codeframe": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/markdown-ansi": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
 				"chalk": "^4.1.0"
 			},
 			"engines": {
@@ -2481,9 +2392,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-			"integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.7.tgz",
+			"integrity": "sha512-gc3hoS6e+2XdIQ4HHljDB1l0Yx2EWh/sBBtCEFNKGSMlwASWeAQsOY/fPbxOBcZ/pg0jBh4Ga+4xHlZc4faAEQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -2499,15 +2410,15 @@
 			}
 		},
 		"node_modules/@parcel/workers": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.0.tgz",
-			"integrity": "sha512-3tcI2LF5fd/WZtSnSjyWdDE+G+FitdNrRgSObzSp+axHKMAM23sO0z7KY8s2SYCF40msdYbFUW8eI6JlYNJoWQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.0.tgz",
+			"integrity": "sha512-vAzoC/wPHLQnyy9P/TrSPftY8F3MhZqPTFi681mxVtLWA3t7wiNlw1zDVKRDP8m5XS1yQOr8Q56CAHyRexhc8g==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chrome-trace-event": "^1.0.2",
 				"nullthrows": "^1.1.1"
 			},
@@ -2519,7 +2430,7 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"peerDependencies": {
-				"@parcel/core": "^2.6.0"
+				"@parcel/core": "^2.8.0"
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -2577,9 +2488,9 @@
 			}
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
-			"integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+			"integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
@@ -2636,9 +2547,9 @@
 			}
 		},
 		"node_modules/@types/chrome": {
-			"version": "0.0.190",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.190.tgz",
-			"integrity": "sha512-lCwwIBfaD+PhG62qFB46mIBpD+xBIa+PedNB24KR9YnmJ0Zn9h0OwP1NQBhI8Cbu1rKwTQHTxhs7GhWGyUvinw==",
+			"version": "0.0.203",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.203.tgz",
+			"integrity": "sha512-JlQNebwpBETVc8U1Rr2inDFuOTtn0lahRAhnddx1dd0S5RrLAFJEEsyIu7AXI14mkCgSunksnuLGioH8kvBqRA==",
 			"dev": true,
 			"dependencies": {
 				"@types/filesystem": "*",
@@ -2984,9 +2895,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -3462,9 +3373,9 @@
 			}
 		},
 		"node_modules/builtins/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3508,42 +3419,42 @@
 			}
 		},
 		"node_modules/camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
+			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
 			"dev": true,
 			"dependencies": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
+				"camelcase": "^7.0.0",
+				"map-obj": "^4.3.0",
+				"quick-lru": "^6.1.1",
+				"type-fest": "^2.13.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/camelcase-keys/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+			"integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/camelcase-keys/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3606,10 +3517,13 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-			"integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
-			"dev": true
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.2",
@@ -3717,10 +3631,10 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+		"node_modules/common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
 			"dev": true
 		},
 		"node_modules/concat-map": {
@@ -3773,9 +3687,9 @@
 			"dev": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"dev": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
@@ -3895,21 +3809,21 @@
 			}
 		},
 		"node_modules/decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"dev": true,
 			"dependencies": {
 				"decamelize": "^1.1.0",
@@ -3917,6 +3831,9 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/decamelize-keys/node_modules/decamelize": {
@@ -4306,13 +4223,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-			"integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+			"version": "8.28.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+			"integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.9.2",
+				"@eslint/eslintrc": "^1.3.3",
+				"@humanwhocodes/config-array": "^0.11.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -4322,18 +4241,21 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
 				"globals": "^13.15.0",
+				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -4344,8 +4266,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -4370,9 +4291,9 @@
 			}
 		},
 		"node_modules/eslint-config-xo": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.41.0.tgz",
-			"integrity": "sha512-cyTc182COQVdalOi5105h0Cw/Qb52IRGyIZLmUICIauANm9Upmv81UEsuFkdKnvwr4NtU95qjdk3g4/kNspA6g==",
+			"version": "0.43.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.43.1.tgz",
+			"integrity": "sha512-azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==",
 			"dev": true,
 			"dependencies": {
 				"confusing-browser-globals": "1.0.11"
@@ -4384,7 +4305,7 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"eslint": ">=8.14.0"
+				"eslint": ">=8.27.0"
 			}
 		},
 		"node_modules/eslint-formatter-pretty": {
@@ -4782,19 +4703,19 @@
 			"dev": true
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "15.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.2.tgz",
-			"integrity": "sha512-MLjZVAv4TiCIoXqjibNqCJjLkGHfrOY3XZ0ZBLoW0OnS3o98PUBnzB/kfp8dCz/4A4Y18jjX50PRnqI4ACFY1Q==",
+			"version": "15.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.5.1.tgz",
+			"integrity": "sha512-kAd+xhZm7brHoFLzKLB7/FGRFJNg/srmv67mqb7tto22rpr4wv/LV6RuXzAfv3jbab7+k1wi42PsIhGviywaaw==",
 			"dev": true,
 			"dependencies": {
 				"builtins": "^5.0.1",
 				"eslint-plugin-es": "^4.1.0",
 				"eslint-utils": "^3.0.0",
 				"ignore": "^5.1.1",
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.11.0",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.10.1",
-				"semver": "^7.3.7"
+				"resolve": "^1.22.1",
+				"semver": "^7.3.8"
 			},
 			"engines": {
 				"node": ">=12.22.0"
@@ -4807,9 +4728,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -4837,15 +4758,15 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-			"integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
 			"dev": true,
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.28.0",
@@ -4858,40 +4779,40 @@
 			}
 		},
 		"node_modules/eslint-plugin-unicorn": {
-			"version": "42.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-			"integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
+			"version": "44.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+			"integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"ci-info": "^3.3.0",
+				"@babel/helper-validator-identifier": "^7.19.1",
+				"ci-info": "^3.4.0",
 				"clean-regexp": "^1.0.0",
 				"eslint-utils": "^3.0.0",
 				"esquery": "^1.4.0",
 				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.1.0",
+				"is-builtin-module": "^3.2.0",
 				"lodash": "^4.17.21",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
 				"regexp-tree": "^0.1.24",
 				"safe-regex": "^2.1.1",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"strip-indent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
 			},
 			"peerDependencies": {
-				"eslint": ">=8.8.0"
+				"eslint": ">=8.23.1"
 			}
 		},
 		"node_modules/eslint-plugin-unicorn/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -4976,6 +4897,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint/node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4988,13 +4925,58 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/esm-utils": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.0.0.tgz",
-			"integrity": "sha512-1x5H25/8BQWV94T8+KRb1gcSdVQ3g+8P0NikggAujVaurUa0cOoR+UO8ie3y29iQO70HjNA93c9ie+qqI/8zzw==",
+		"node_modules/eslint/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"dependencies": {
-				"import-meta-resolve": "1.1.1",
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/esm-utils": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.1.1.tgz",
+			"integrity": "sha512-cTy4OQgEP/yc7RY3s6EgwMGZ10gAPhCLE9FcrQ6/5bhf37o9PZCFSjzQR1tYb4GaKAEMaW1UmDcMZR13H4p6LQ==",
+			"dev": true,
+			"dependencies": {
+				"import-meta-resolve": "2.2.0",
 				"url-or-path": "2.1.0"
 			},
 			"funding": {
@@ -5002,17 +4984,20 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-			"integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esprima": {
@@ -5291,20 +5276,116 @@
 			}
 		},
 		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+			"integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
 			"dev": true,
 			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.16"
 			},
 			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/find-up": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^7.1.0",
+				"path-exists": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/locate-path": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
+			"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^6.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-limit": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-locate": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/path-exists": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/pkg-dir": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+			"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/yocto-queue": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/find-file-up": {
@@ -5483,12 +5564,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
 		},
 		"node_modules/functions-have-names": {
 			"version": "1.2.3",
@@ -5729,6 +5804,12 @@
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
+		"node_modules/grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
 		"node_modules/hard-rejection": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -5820,15 +5901,24 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -5838,9 +5928,9 @@
 			"dev": true
 		},
 		"node_modules/htmlnano": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-			"integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+			"integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
 			"dev": true,
 			"dependencies": {
 				"cosmiconfig": "^7.0.1",
@@ -5850,9 +5940,9 @@
 			"peerDependencies": {
 				"cssnano": "^5.0.11",
 				"postcss": "^8.3.11",
-				"purgecss": "^4.0.3",
+				"purgecss": "^5.0.0",
 				"relateurl": "^0.2.7",
-				"srcset": "^5.0.0",
+				"srcset": "4.0.0",
 				"svgo": "^2.8.0",
 				"terser": "^5.10.0",
 				"uncss": "^0.17.3"
@@ -5990,40 +6080,13 @@
 			}
 		},
 		"node_modules/import-meta-resolve": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-1.1.1.tgz",
-			"integrity": "sha512-JiTuIvVyPaUg11eTrNDx5bgQ/yMKMZffc7YSjvQeSMXy58DO2SQ8BtAf3xteZvmzvjYh14wnqNjL8XVeDy2o9A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.0.tgz",
+			"integrity": "sha512-CpPOtiCHxP9HdtDM5F45tNiAe66Cqlv3f5uHoJjt+KlaLrUh9/Wz9vepADZ78SlqEo62aDWZtj9ydMGXV+CPnw==",
 			"dev": true,
-			"dependencies": {
-				"builtins": "^4.0.0"
-			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/import-meta-resolve/node_modules/builtins": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/builtins/-/builtins-4.1.0.tgz",
-			"integrity": "sha512-1bPRZQtmKaO6h7qV1YHXNtr6nCK28k0Zo95KM4dXfILcZZwoHJBN1m3lfLv9LPkcOZlrSr+J1bzMaZFO98Yq0w==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^7.0.0"
-			}
-		},
-		"node_modules/import-meta-resolve/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/import-modules": {
@@ -6173,15 +6236,18 @@
 			"dev": true
 		},
 		"node_modules/is-builtin-module": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
 			"dev": true,
 			"dependencies": {
-				"builtin-modules": "^3.0.0"
+				"builtin-modules": "^3.3.0"
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-callable": {
@@ -6197,9 +6263,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -6364,6 +6430,15 @@
 			"dependencies": {
 				"lowercase-keys": "^1.0.0",
 				"obj-props": "^1.0.0"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -7415,6 +7490,16 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
+		"node_modules/js-sdsl": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+			"integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7537,6 +7622,192 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.1.tgz",
+			"integrity": "sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==",
+			"dev": true,
+			"dependencies": {
+				"detect-libc": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-darwin-arm64": "1.16.1",
+				"lightningcss-darwin-x64": "1.16.1",
+				"lightningcss-linux-arm-gnueabihf": "1.16.1",
+				"lightningcss-linux-arm64-gnu": "1.16.1",
+				"lightningcss-linux-arm64-musl": "1.16.1",
+				"lightningcss-linux-x64-gnu": "1.16.1",
+				"lightningcss-linux-x64-musl": "1.16.1",
+				"lightningcss-win32-x64-msvc": "1.16.1"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.1.tgz",
+			"integrity": "sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.1.tgz",
+			"integrity": "sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.1.tgz",
+			"integrity": "sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.1.tgz",
+			"integrity": "sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.1.tgz",
+			"integrity": "sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.1.tgz",
+			"integrity": "sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.1.tgz",
+			"integrity": "sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.1.tgz",
+			"integrity": "sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/line-column-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-3.0.0.tgz",
@@ -7571,105 +7842,26 @@
 			"dev": true
 		},
 		"node_modules/lmdb": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
-			"integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+			"integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"msgpackr": "^1.5.4",
-				"nan": "^2.14.2",
 				"node-addon-api": "^4.3.0",
-				"node-gyp-build-optional-packages": "^4.3.2",
+				"node-gyp-build-optional-packages": "5.0.3",
 				"ordered-binary": "^1.2.4",
 				"weak-lru-cache": "^1.2.2"
 			},
 			"optionalDependencies": {
-				"lmdb-darwin-arm64": "2.3.10",
-				"lmdb-darwin-x64": "2.3.10",
-				"lmdb-linux-arm": "2.3.10",
-				"lmdb-linux-arm64": "2.3.10",
-				"lmdb-linux-x64": "2.3.10",
-				"lmdb-win32-x64": "2.3.10"
+				"@lmdb/lmdb-darwin-arm64": "2.5.2",
+				"@lmdb/lmdb-darwin-x64": "2.5.2",
+				"@lmdb/lmdb-linux-arm": "2.5.2",
+				"@lmdb/lmdb-linux-arm64": "2.5.2",
+				"@lmdb/lmdb-linux-x64": "2.5.2",
+				"@lmdb/lmdb-win32-x64": "2.5.2"
 			}
-		},
-		"node_modules/lmdb-darwin-arm64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
-			"integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/lmdb-darwin-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
-			"integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/lmdb-linux-arm": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
-			"integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/lmdb-linux-arm64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
-			"integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/lmdb-linux-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
-			"integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/lmdb-win32-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
-			"integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/lmdb/node_modules/node-addon-api": {
 			"version": "4.3.0",
@@ -7812,23 +8004,39 @@
 			"dev": true
 		},
 		"node_modules/meow": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
-			"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
+			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
 			"dev": true,
 			"dependencies": {
 				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
+				"camelcase-keys": "^8.0.2",
+				"decamelize": "^6.0.0",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
 				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
+				"normalize-package-data": "^4.0.1",
+				"read-pkg-up": "^9.1.0",
 				"redent": "^4.0.0",
 				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
+				"type-fest": "^3.1.0",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/find-up": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^7.1.0",
+				"path-exists": "^5.0.0"
 			},
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -7837,109 +8045,180 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/meow/node_modules/find-up": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+		"node_modules/meow/node_modules/hosted-git-info": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 			"dev": true,
 			"dependencies": {
-				"locate-path": "^6.0.0",
-				"path-exists": "^4.0.0"
+				"lru-cache": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/meow/node_modules/locate-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
+			"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
 			"dev": true,
 			"dependencies": {
-				"p-locate": "^5.0.0"
+				"p-locate": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/meow/node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
 			"dev": true,
 			"dependencies": {
-				"yocto-queue": "^0.1.0"
+				"yocto-queue": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/meow/node_modules/p-locate": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
 			"dev": true,
 			"dependencies": {
-				"p-limit": "^3.0.2"
+				"p-limit": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/meow/node_modules/path-exists": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
 		"node_modules/meow/node_modules/read-pkg": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+			"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
 			"dev": true,
 			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
+				"@types/normalize-package-data": "^2.4.1",
 				"normalize-package-data": "^3.0.2",
 				"parse-json": "^5.2.0",
-				"type-fest": "^1.0.1"
+				"type-fest": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/meow/node_modules/read-pkg-up": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+			"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
 			"dev": true,
 			"dependencies": {
-				"find-up": "^5.0.0",
-				"read-pkg": "^6.0.0",
-				"type-fest": "^1.0.1"
+				"find-up": "^6.3.0",
+				"read-pkg": "^7.1.0",
+				"type-fest": "^2.5.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+		"node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
 			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^4.0.1",
+				"is-core-module": "^2.5.0",
+				"semver": "^7.3.4",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/type-fest": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+			"integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/yocto-queue": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8158,12 +8437,6 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
-		"node_modules/nan": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-			"integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-			"dev": true
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8204,9 +8477,9 @@
 			}
 		},
 		"node_modules/node-gyp-build": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
 			"dev": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
@@ -8215,9 +8488,9 @@
 			}
 		},
 		"node_modules/node-gyp-build-optional-packages": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
-			"integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+			"integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
 			"dev": true,
 			"bin": {
 				"node-gyp-build-optional-packages": "bin.js",
@@ -8238,24 +8511,24 @@
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
 			"dev": true,
 			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "^5.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -8454,9 +8727,9 @@
 			}
 		},
 		"node_modules/ordered-binary": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
-			"integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
+			"integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
 			"dev": true
 		},
 		"node_modules/os-homedir": {
@@ -8505,21 +8778,21 @@
 			}
 		},
 		"node_modules/parcel": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.0.tgz",
-			"integrity": "sha512-pSTJ7wC6uTl16PKLXQV7RfL9FGoIDA1iVpNvaav47n6UkUdKqfx0spcVPpw35kWdRcHJF61YAvkPjP2hTwHQ+Q==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.0.tgz",
+			"integrity": "sha512-p7Fo75CeMw5HC1luovYpBjzPbAJv/Gn7lxcs4f0LxcwBCWbkQ73zHgJXJQqnM38qQABEYEiQq6000+j+k5U/Mw==",
 			"dev": true,
 			"dependencies": {
-				"@parcel/config-default": "2.6.0",
-				"@parcel/core": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/reporter-cli": "2.6.0",
-				"@parcel/reporter-dev-server": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/config-default": "2.8.0",
+				"@parcel/core": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/reporter-cli": "2.8.0",
+				"@parcel/reporter-dev-server": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chalk": "^4.1.0",
 				"commander": "^7.0.0",
 				"get-port": "^4.2.0",
@@ -8760,9 +9033,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
-			"integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+			"integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
@@ -8914,12 +9187,12 @@
 			]
 		},
 		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+			"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9082,9 +9355,9 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"dev": true
 		},
 		"node_modules/regexp-tree": {
@@ -9135,12 +9408,12 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.8.1",
+				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -9476,9 +9749,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"node_modules/sprintf-js": {
@@ -9491,6 +9764,7 @@
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
 			"dev": true
 		},
 		"node_modules/stack-utils": {
@@ -10033,9 +10307,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -10212,9 +10486,9 @@
 			}
 		},
 		"node_modules/webext-content-scripts": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-1.0.2.tgz",
-			"integrity": "sha512-gC+afnJFmsjBxtJAkG1bEUGnpedVMJq2wqEpswrZTuC3T4sAozkeJvC4GdZ/SjKDvj+HR0qcIQqVCWmlCv96DQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-1.0.3.tgz",
+			"integrity": "sha512-Kwd6V/Dbbfl136e30aXd319IZPy3TvgKqqF834vlkOp/ALzEE8caPEbbjGHSQjt/zJVr3vtlUQOWP7GUH8WJlA==",
 			"dependencies": {
 				"webext-polyfill-kinda": "^0.10.0"
 			},
@@ -10452,9 +10726,9 @@
 			}
 		},
 		"node_modules/xo": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.50.0.tgz",
-			"integrity": "sha512-yIz7mdIbUlxBYLnV3OqMTdrE+OFr0CPINkU9rxY3ZHNAIZrVckmONLujU6LkdNrEWerQTx8zzwnVrUjmj6vVCg==",
+			"version": "0.53.1",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.53.1.tgz",
+			"integrity": "sha512-/2R8SPehv1UhiIqJ9uSvrAjslcoygICNsUlEb/Zf2V6rMtr7YCoggc6hlt6b/kbncpR989Roqt6AvEO779dFxw==",
 			"bundleDependencies": [
 				"@typescript-eslint/eslint-plugin",
 				"@typescript-eslint/parser",
@@ -10462,48 +10736,48 @@
 			],
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@typescript-eslint/eslint-plugin": "*",
-				"@typescript-eslint/parser": "*",
+				"@eslint/eslintrc": "^1.3.3",
+				"@typescript-eslint/eslint-plugin": "^5.43.0",
+				"@typescript-eslint/parser": "^5.43.0",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^7.0.1",
+				"cosmiconfig": "^7.1.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.17.0",
+				"eslint": "^8.27.0",
 				"eslint-config-prettier": "^8.5.0",
-				"eslint-config-xo": "^0.41.0",
-				"eslint-config-xo-typescript": "*",
+				"eslint-config-xo": "^0.43.1",
+				"eslint-config-xo-typescript": "^0.55.0",
 				"eslint-formatter-pretty": "^4.1.0",
 				"eslint-import-resolver-webpack": "^0.13.2",
 				"eslint-plugin-ava": "^13.2.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-import": "^2.26.0",
-				"eslint-plugin-n": "^15.2.2",
+				"eslint-plugin-n": "^15.5.1",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-prettier": "^4.0.0",
-				"eslint-plugin-unicorn": "^42.0.0",
-				"esm-utils": "^4.0.0",
-				"find-cache-dir": "^3.3.2",
+				"eslint-plugin-prettier": "^4.2.1",
+				"eslint-plugin-unicorn": "^44.0.2",
+				"esm-utils": "^4.1.0",
+				"find-cache-dir": "^4.0.0",
 				"find-up": "^6.3.0",
 				"get-stdin": "^9.0.0",
-				"globby": "^13.1.1",
+				"globby": "^13.1.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"json5": "^2.2.1",
 				"lodash-es": "^4.17.21",
-				"meow": "^10.1.2",
+				"meow": "^11.0.0",
 				"micromatch": "^4.0.5",
 				"open-editor": "^4.0.0",
-				"prettier": "^2.6.2",
-				"semver": "^7.3.7",
-				"slash": "^4.0.0",
+				"prettier": "^2.7.1",
+				"semver": "^7.3.8",
+				"slash": "^5.0.0",
 				"to-absolute-glob": "^2.0.2",
-				"typescript": "^4.7.3"
+				"typescript": "^4.9.3"
 			},
 			"bin": {
 				"xo": "cli.js"
 			},
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -10550,18 +10824,24 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/xo/node_modules/@types/semver": {
+			"version": "7.3.13",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.27.1",
-				"@typescript-eslint/type-utils": "5.27.1",
-				"@typescript-eslint/utils": "5.27.1",
+				"@typescript-eslint/scope-manager": "5.43.0",
+				"@typescript-eslint/type-utils": "5.43.0",
+				"@typescript-eslint/utils": "5.43.0",
 				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
@@ -10584,14 +10864,14 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/parser": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.27.1",
-				"@typescript-eslint/types": "5.27.1",
-				"@typescript-eslint/typescript-estree": "5.27.1",
+				"@typescript-eslint/scope-manager": "5.43.0",
+				"@typescript-eslint/types": "5.43.0",
+				"@typescript-eslint/typescript-estree": "5.43.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -10611,13 +10891,13 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.27.1",
-				"@typescript-eslint/visitor-keys": "5.27.1"
+				"@typescript-eslint/types": "5.43.0",
+				"@typescript-eslint/visitor-keys": "5.43.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -10628,12 +10908,13 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/type-utils": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "5.27.1",
+				"@typescript-eslint/typescript-estree": "5.43.0",
+				"@typescript-eslint/utils": "5.43.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -10654,7 +10935,7 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/types": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -10667,13 +10948,13 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "5.27.1",
-				"@typescript-eslint/visitor-keys": "5.27.1",
+				"@typescript-eslint/types": "5.43.0",
+				"@typescript-eslint/visitor-keys": "5.43.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -10723,17 +11004,19 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/utils": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.27.1",
-				"@typescript-eslint/types": "5.27.1",
-				"@typescript-eslint/typescript-estree": "5.27.1",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.43.0",
+				"@typescript-eslint/types": "5.43.0",
+				"@typescript-eslint/typescript-estree": "5.43.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"eslint-utils": "^3.0.0",
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -10747,12 +11030,12 @@
 			}
 		},
 		"node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.27.1",
+			"version": "5.43.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.27.1",
+				"@typescript-eslint/types": "5.43.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -10820,7 +11103,7 @@
 			}
 		},
 		"node_modules/xo/node_modules/eslint-config-xo-typescript": {
-			"version": "0.51.1",
+			"version": "0.55.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -10831,7 +11114,8 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": ">=5.22.0",
+				"@typescript-eslint/eslint-plugin": ">=5.43.0",
+				"@typescript-eslint/parser": ">=5.43.0",
 				"eslint": ">=8.0.0",
 				"typescript": ">=4.4"
 			}
@@ -10916,7 +11200,7 @@
 			}
 		},
 		"node_modules/xo/node_modules/fast-glob": {
-			"version": "3.2.11",
+			"version": "3.2.12",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -10967,12 +11251,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/xo/node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/xo/node_modules/glob-parent": {
 			"version": "5.1.2",
@@ -11040,18 +11318,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/xo/node_modules/merge2": {
 			"version": "1.4.1",
 			"dev": true,
@@ -11073,6 +11339,12 @@
 			"engines": {
 				"node": ">=8.6"
 			}
+		},
+		"node_modules/xo/node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
 		},
 		"node_modules/xo/node_modules/p-limit": {
 			"version": "4.0.0",
@@ -11200,7 +11472,7 @@
 			}
 		},
 		"node_modules/xo/node_modules/semver": {
-			"version": "7.3.7",
+			"version": "7.3.8",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -11214,13 +11486,25 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/xo/node_modules/semver/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/xo/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.0.0.tgz",
+			"integrity": "sha512-n6KkmvKS0623igEVj3FF0OZs1gYYJ0o0Hj939yc1fyxl2xt+xYpLnzJB6xBSqOfV9ZFLEWodBBN/heZJahuIJQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11326,18 +11610,9 @@
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yargs/node_modules/yargs-parser": {
-			"version": "21.0.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -11542,9 +11817,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -11810,14 +12085,14 @@
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"globals": "^13.15.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -11859,15 +12134,21 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.9.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+			"version": "0.11.7",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			}
+		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
 			"version": "1.2.1",
@@ -12199,6 +12480,48 @@
 				"@lezer/common": "^0.15.0"
 			}
 		},
+		"@lmdb/lmdb-darwin-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+			"integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+			"dev": true,
+			"optional": true
+		},
+		"@lmdb/lmdb-darwin-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+			"integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+			"dev": true,
+			"optional": true
+		},
+		"@lmdb/lmdb-linux-arm": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+			"integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+			"dev": true,
+			"optional": true
+		},
+		"@lmdb/lmdb-linux-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+			"integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@lmdb/lmdb-linux-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+			"integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@lmdb/lmdb-win32-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+			"integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+			"dev": true,
+			"optional": true
+		},
 		"@mischnic/json-sourcemap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -12279,119 +12602,120 @@
 			}
 		},
 		"@parcel/bundler-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.0.tgz",
-			"integrity": "sha512-AplEdGm/odV7yGmoeOnglxnY31WlNB5EqGLFGxkgs7uwDaTWoTX/9SWPG6xfvirhjDpms8sLSiVuBdFRCCLtNA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.8.0.tgz",
+			"integrity": "sha512-OvDDhxX4LwfGe7lYVMbJMzqNcDk8ydOqNw0Hra9WPgl0m5gju/eVIbDvot3JXp5F96FmV36uCxdODJhKTNoAzQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/graph": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/cache": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.0.tgz",
-			"integrity": "sha512-4vbD5uSuf+kRnrFesKhpn0AKnOw8u2UlvCyrplYmp1g9bNAkIooC/nDGdmkb/9SviPEbni9PEanQEHDU2+slpA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.0.tgz",
+			"integrity": "sha512-k945hrafMDR2wyCKyZYgwypeLLuZWce6FzhgunI4taBUeVnNCcpFAWzbfOVQ39SqZTGDqG3MNT+VuehssHXxyg==",
 			"dev": true,
 			"requires": {
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"lmdb": "2.3.10"
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"lmdb": "2.5.2"
 			}
 		},
 		"@parcel/codeframe": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.0.tgz",
-			"integrity": "sha512-yXXxrO9yyedHKpTwC+Af0+vPmQm+A9xeEhkt4f0yVg1n4t4yUIxYlTedzbM8ygZEEBtkXU9jJ+PkgXbfMf0dqw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.0.tgz",
+			"integrity": "sha512-821d+KVcpEvJNMj9WMC39xXZK6zvRS/HUjQag2f3DkcRcZwk1uXJZdW6p1EB7C3e4e/0KSK3NTSVGEvbOSR+9w==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0"
 			}
 		},
 		"@parcel/compressor-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.0.tgz",
-			"integrity": "sha512-rtMU2mGl88bic6Xbq1u5L49bMK4s5185b0k7h3JRdS6/0rR+Xp4k/o9Wog+hHjK/s82z1eF9WmET779ZpIDIQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.8.0.tgz",
+			"integrity": "sha512-tM49t0gDQnwJbrDCeoCn9LRc8inZ/TSPQTttJTfcmFHHFqEllI0ZDVG0AiQw5NOMQbBLYiKun1adXn8pkcPLEA==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			}
 		},
 		"@parcel/config-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.6.0.tgz",
-			"integrity": "sha512-DXovFPhZITmTvFaSEdC8RRqROs9FLIJ4u8yFSU6FUyq2wpvtYVRXXoDrvXgClh2csXmK7JTJTp5JF7r0rd2UaA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.8.0.tgz",
+			"integrity": "sha512-j9g50QNSLjuNpY0TP01EgGJPxWNes9d+e8+N07Z5Wv0u+UUnJ2uIOpo7PVn7ullOGhm1f9lP4KsJenu5gWb+cg==",
 			"dev": true,
 			"requires": {
-				"@parcel/bundler-default": "2.6.0",
-				"@parcel/compressor-raw": "2.6.0",
-				"@parcel/namer-default": "2.6.0",
-				"@parcel/optimizer-css": "2.6.0",
-				"@parcel/optimizer-htmlnano": "2.6.0",
-				"@parcel/optimizer-image": "2.6.0",
-				"@parcel/optimizer-svgo": "2.6.0",
-				"@parcel/optimizer-terser": "2.6.0",
-				"@parcel/packager-css": "2.6.0",
-				"@parcel/packager-html": "2.6.0",
-				"@parcel/packager-js": "2.6.0",
-				"@parcel/packager-raw": "2.6.0",
-				"@parcel/packager-svg": "2.6.0",
-				"@parcel/reporter-dev-server": "2.6.0",
-				"@parcel/resolver-default": "2.6.0",
-				"@parcel/runtime-browser-hmr": "2.6.0",
-				"@parcel/runtime-js": "2.6.0",
-				"@parcel/runtime-react-refresh": "2.6.0",
-				"@parcel/runtime-service-worker": "2.6.0",
-				"@parcel/transformer-babel": "2.6.0",
-				"@parcel/transformer-css": "2.6.0",
-				"@parcel/transformer-html": "2.6.0",
-				"@parcel/transformer-image": "2.6.0",
-				"@parcel/transformer-js": "2.6.0",
-				"@parcel/transformer-json": "2.6.0",
-				"@parcel/transformer-postcss": "2.6.0",
-				"@parcel/transformer-posthtml": "2.6.0",
-				"@parcel/transformer-raw": "2.6.0",
-				"@parcel/transformer-react-refresh-wrap": "2.6.0",
-				"@parcel/transformer-svg": "2.6.0"
+				"@parcel/bundler-default": "2.8.0",
+				"@parcel/compressor-raw": "2.8.0",
+				"@parcel/namer-default": "2.8.0",
+				"@parcel/optimizer-css": "2.8.0",
+				"@parcel/optimizer-htmlnano": "2.8.0",
+				"@parcel/optimizer-image": "2.8.0",
+				"@parcel/optimizer-svgo": "2.8.0",
+				"@parcel/optimizer-terser": "2.8.0",
+				"@parcel/packager-css": "2.8.0",
+				"@parcel/packager-html": "2.8.0",
+				"@parcel/packager-js": "2.8.0",
+				"@parcel/packager-raw": "2.8.0",
+				"@parcel/packager-svg": "2.8.0",
+				"@parcel/reporter-dev-server": "2.8.0",
+				"@parcel/resolver-default": "2.8.0",
+				"@parcel/runtime-browser-hmr": "2.8.0",
+				"@parcel/runtime-js": "2.8.0",
+				"@parcel/runtime-react-refresh": "2.8.0",
+				"@parcel/runtime-service-worker": "2.8.0",
+				"@parcel/transformer-babel": "2.8.0",
+				"@parcel/transformer-css": "2.8.0",
+				"@parcel/transformer-html": "2.8.0",
+				"@parcel/transformer-image": "2.8.0",
+				"@parcel/transformer-js": "2.8.0",
+				"@parcel/transformer-json": "2.8.0",
+				"@parcel/transformer-postcss": "2.8.0",
+				"@parcel/transformer-posthtml": "2.8.0",
+				"@parcel/transformer-raw": "2.8.0",
+				"@parcel/transformer-react-refresh-wrap": "2.8.0",
+				"@parcel/transformer-svg": "2.8.0"
 			}
 		},
 		"@parcel/config-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.6.0.tgz",
-			"integrity": "sha512-CjFo5gnFgwIlF+kt89jRrf4yHMb56sgyE/h9o0hBmg5UaptvR7iTRcp3c9J0dqRF09BaPdsN6clOGthKZW/jlw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/config-webextension/-/config-webextension-2.8.0.tgz",
+			"integrity": "sha512-80gtgNU77kT1DY9SXNt8CwBgHLu5qWwmo0sw2SCMzg+iXYSj8WAuESAN56O6J+Su3IWs+IzF6MdCAYFTyGM5mA==",
 			"dev": true,
 			"requires": {
-				"@parcel/config-default": "2.6.0",
-				"@parcel/packager-webextension": "2.6.0",
-				"@parcel/runtime-webextension": "2.6.0",
-				"@parcel/transformer-raw": "2.6.0",
-				"@parcel/transformer-webextension": "2.6.0"
+				"@parcel/config-default": "2.8.0",
+				"@parcel/packager-webextension": "2.8.0",
+				"@parcel/runtime-webextension": "2.8.0",
+				"@parcel/transformer-raw": "2.8.0",
+				"@parcel/transformer-webextension": "2.8.0"
 			}
 		},
 		"@parcel/core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.0.tgz",
-			"integrity": "sha512-8OOWbPuxpFydpwNyKoz6d3e3O4DmxNYmMw4DXwrPSj/jyg7oa+SDtMT0/VXEhujE0HYkQPCHt4npRajkSuf99A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
+			"integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
 			"dev": true,
 			"requires": {
 				"@mischnic/json-sourcemap": "^0.1.0",
-				"@parcel/cache": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/graph": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/cache": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/graph": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"abortcontroller-polyfill": "^1.1.9",
 				"base-x": "^3.0.8",
 				"browserslist": "^4.6.6",
@@ -12404,83 +12728,10 @@
 				"semver": "^5.7.1"
 			}
 		},
-		"@parcel/css": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.10.0.tgz",
-			"integrity": "sha512-YvlUqJ3kg/HxsVvq02bTCGruQKjwPEMWEqdyhgfR3aagt+1ibmafy3m8CGYHXvhaQeNYSkMvy1D9bcddFuYTUg==",
-			"dev": true,
-			"requires": {
-				"@parcel/css-darwin-arm64": "1.10.0",
-				"@parcel/css-darwin-x64": "1.10.0",
-				"@parcel/css-linux-arm-gnueabihf": "1.10.0",
-				"@parcel/css-linux-arm64-gnu": "1.10.0",
-				"@parcel/css-linux-arm64-musl": "1.10.0",
-				"@parcel/css-linux-x64-gnu": "1.10.0",
-				"@parcel/css-linux-x64-musl": "1.10.0",
-				"@parcel/css-win32-x64-msvc": "1.10.0",
-				"detect-libc": "^1.0.3"
-			}
-		},
-		"@parcel/css-darwin-arm64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.10.0.tgz",
-			"integrity": "sha512-WMAbjUyCBrXwv3OofNk90K+G0DqZgCFRtKCg+udLXLZCiCe6yrI87ye9SC6KAVwqWp5WT27TPZTrqWJ032e3FA==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-darwin-x64": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.10.0.tgz",
-			"integrity": "sha512-p1JJVHOOxrhcSQMq9qlrU88Sl+VJGu8HXBpWDHRzh8aOIkqsiRx1qx9Vl3zGX7Sxnjv/xlPUknLKia8Zy1369A==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-linux-arm-gnueabihf": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.10.0.tgz",
-			"integrity": "sha512-cUvDN+nNEdoEzZLhOqPAcjICIyEGcFCc0+zJhGKdnA9MC010aeun9ggtToFazIHzMmoF4qyxCY5IyHja8iVkmA==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-linux-arm64-gnu": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.10.0.tgz",
-			"integrity": "sha512-x8XEtJxgJlstAwbg1BLeYuXhUXEOxGg/BeBFPZr8Zk8dNQ1j1jR7LBk12IKgZrvr+Px1WOFY65lwabgCyFqxnQ==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-linux-arm64-musl": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.10.0.tgz",
-			"integrity": "sha512-caBaOM+zhFYlaMB2GL327NeOkF5lbHte5XLrGByagLWanlnRRlFpapIXpuuGIGSF5uBHN2uAz/84ej5mNcdHwg==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-linux-x64-gnu": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.10.0.tgz",
-			"integrity": "sha512-9JZUMB1v+Zh95K2BJdoC20vZcObqF3mPA10gM51/a44f3rhRsv/EHjzLsSqxSYtC+L7wLvW9M3SNZ2KTo0J2/A==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-linux-x64-musl": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.10.0.tgz",
-			"integrity": "sha512-U702L0HlZUN5Fxb6jbDetYeA7eOgLHkXo4vZ9/XHJyPy6jD+n+9HO8bEcLdSAadJcb4Ndcn89THyfwKiOHukVQ==",
-			"dev": true,
-			"optional": true
-		},
-		"@parcel/css-win32-x64-msvc": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.10.0.tgz",
-			"integrity": "sha512-44GtojxQBRf8yTetsNdjYSa2KL4/UpSbEeaOYcO+PKBGHcCyQX2Lex5r1X2pXkpNxvu142+dSTLeXhBSFG4C0g==",
-			"dev": true,
-			"optional": true
-		},
 		"@parcel/diagnostic": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.0.tgz",
-			"integrity": "sha512-+p8gC2FKxSI2veD7SoaNlP572v4kw+nafCQEPDtJuzYYRqywYUGncch25dkpgNApB4W4cXVkZu3ZbtIpCAmjQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.0.tgz",
+			"integrity": "sha512-ERnk0zDvm0jQUSj1M+2PLiwVC6nWrtuFEuye6VGuxRDcp9NHbz6gwApeEYxFkPsb3TQPhNjnXXm5nmAw1bpWWw==",
 			"dev": true,
 			"requires": {
 				"@mischnic/json-sourcemap": "^0.1.0",
@@ -12488,47 +12739,47 @@
 			}
 		},
 		"@parcel/events": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.0.tgz",
-			"integrity": "sha512-2WaKtBs4iYwS88j4zRdyTJTgh8iuY4E32FMmjzzbheqETs6I05gWuPReGukJYxk8vc0Ir7tbzp12oAfpgo0Y+g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.0.tgz",
+			"integrity": "sha512-xqSZYY3oONM4IZm9+vhyFqX+KFIl145veIczUikwGJlcJZQfAAw736syPx6ecpB+m1EVg3AlvJWy7Lmel4Ak+Q==",
 			"dev": true
 		},
 		"@parcel/fs": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.0.tgz",
-			"integrity": "sha512-6vxtx5Zy6MvDvH1EPx9JxjKGF03bR7VE1dUf4HLeX2D8YmpL5hkHJnlRCFdcH08rzOVwaJLzg1QNtblWJXQ9CA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.0.tgz",
+			"integrity": "sha512-v3DbJlpl8v2/VRlZPw7cy+0myi0YfLblGZcwDvqIsWS35qyxD2rmtYV8u1BusonbgmJeaKiopSECmJkumt0jCw==",
 			"dev": true,
 			"requires": {
-				"@parcel/fs-search": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/watcher": "^2.0.0",
-				"@parcel/workers": "2.6.0"
+				"@parcel/fs-search": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/watcher": "^2.0.7",
+				"@parcel/workers": "2.8.0"
 			}
 		},
 		"@parcel/fs-search": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.0.tgz",
-			"integrity": "sha512-1nXzM3H/cA4kzLKvDBvwmNisKCdRqlgkLXh+OR1Zu28Kn4W34KuJMcHWW8cC+WIuuKqDh5oo2WPsC5y65GXBKQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.0.tgz",
+			"integrity": "sha512-yo7/Y8DCFlhOlIBb5SsRDTkM+7g0DY9sK57iw3hn2z1tGoIiIRptrieImFYSizs7HfDwDY/PMLfORmUdoReDzQ==",
 			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3"
 			}
 		},
 		"@parcel/graph": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.0.tgz",
-			"integrity": "sha512-rxrAzWm6rwbCRPbu0Z+zwMscpG8omffODniVWPlX2G0jgQGpjKsutBQ6RMfFIcfaQ4MzL3pIQOTf8bkjQOPsbg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.0.tgz",
+			"integrity": "sha512-JvAyvBpGmhZ30bi+hStQr52eu+InfJBoiN9Z/32byIWhXEl02EAOwfsPqAe+FGCsdgXnnCGg5F9ZCqwzZ9dwbw==",
 			"dev": true,
 			"requires": {
-				"@parcel/utils": "2.6.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/hash": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.0.tgz",
-			"integrity": "sha512-YugWqhLxqK80Lo++3B3Kr5UPCHOdS8iI2zJ1jkzUeH9v6WUzbwWOnmPf6lN2S5m1BrIFFJd8Jc+CbEXWi8zoJA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.0.tgz",
+			"integrity": "sha512-KV1+96t7Nukth5K7ldUXjVr8ZTH9Dohl49K0Tc+5Qkysif0OxwcDtpVDmcnrUnWmqdBX0AdoLY0Q2Nnly89n/w==",
 			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
@@ -12536,68 +12787,69 @@
 			}
 		},
 		"@parcel/logger": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.0.tgz",
-			"integrity": "sha512-J1/7kPfSGBvMKSZdi0WCNuN0fIeiWxifnDGn7W/K8KhD422YwFJA8N046ps8nkDOPIXf1osnIECNp4GIR9oSYw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.0.tgz",
+			"integrity": "sha512-W+7rKsLxLUX6xRmP8PhGWcG48PqrzTPeMWpgSds5nXxAHEFh4cYbkwPKGoTU65a9xUDVyqNreHNIKyizgwAZHQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0"
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0"
 			}
 		},
 		"@parcel/markdown-ansi": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.0.tgz",
-			"integrity": "sha512-fyjkrJQQSfKTUFTTasdZ6WrAkDoQ2+DYDjj+3p+RncYyrIa9zArKx4IiRiipsvNdtMvP0/hTdK8F3BOJ3KSU/g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.0.tgz",
+			"integrity": "sha512-xItzXmc3btFhJXsIbE946iaqE6STd2xe5H0zSIaZVXEeucCtMzcd4hxRELquxPstlrAOrrp/lrRpbAlMhso9iA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0"
 			}
 		},
 		"@parcel/namer-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-			"integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.0.tgz",
+			"integrity": "sha512-cVCx2kJA/Bv7O9pVad1UOibaybR/B+QdWV8Ols8HH4lC2gyjLBXEIR0uuPSEbkGwMEcofG6zA3MwsoPa6r5lBg==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/node-resolver-core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.0.tgz",
-			"integrity": "sha512-AJDj5DZbB58plv0li8bdVSD+zpnkHE36Om3TYyNn1jgXXwgBM64Er/9p8yQn356jBqTQMh7zlJqvbdIyOiMeMg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.8.0.tgz",
+			"integrity": "sha512-cECSh08NSRt1csmmMeKxlnO6ZhXRTuRijkHKFa4iG5hPL+3Cu04YGhuK/QWlP5vNCPVrH3ISlhzlPU5fAi/nEg==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"nullthrows": "^1.1.1"
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"nullthrows": "^1.1.1",
+				"semver": "^5.7.1"
 			}
 		},
 		"@parcel/optimizer-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.6.0.tgz",
-			"integrity": "sha512-VMJknUwfKCw6Woov0lnPGdsGZewcI4ghW8WKmNZzC5uKCetk1XetV55QHBc1RNjGfsjfSTZiSa3guATj2zFJkQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.0.tgz",
+			"integrity": "sha512-T5r3gZVm1xFw6l//iLkzLDUvFzNTUvL5kAtyU5gS5yH/dg7eCS09Km/c2anViQnmXwFUt7zIlBovj1doxAVNSw==",
 			"dev": true,
 			"requires": {
-				"@parcel/css": "^1.9.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
+				"lightningcss": "^1.16.1",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/optimizer-htmlnano": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.6.0.tgz",
-			"integrity": "sha512-HmvcUoYpfdx8ZfID4WOj/SE8N78NEBmzAffZ8f827mYMr4ZrbKzAgg6OG3tBbfF0zxH0bIjZcwqwZYk4SdbG7g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.8.0.tgz",
+			"integrity": "sha512-NxEKTRvue/WAU+XbQGfNIU6c7chDekdkwwv9YnCxHEOhnBu4Ok+2tdmCtPuA+4UUNszGxXlaHMnqSrjmqX2S6Q==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
+				"@parcel/plugin": "2.8.0",
 				"htmlnano": "^2.0.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
@@ -12605,247 +12857,247 @@
 			}
 		},
 		"@parcel/optimizer-image": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.6.0.tgz",
-			"integrity": "sha512-FDNr3LJ8SWR9rrtdCrZOlYF1hE9G5pxUWawGxUasbvqwcY5lEQwr2KRmfGZeg+KwOnzlImlY6dP2LGox1NFddQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.8.0.tgz",
+			"integrity": "sha512-66eSoCCGZVRiY6U4OqqYrhQcBcHI9cOkIEbxadZYOF4cJhsskjUDJR0jLb4j2PE6QxUNYlyj5OglQqRLwhz7vA==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"detect-libc": "^1.0.3"
 			}
 		},
 		"@parcel/optimizer-svgo": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.6.0.tgz",
-			"integrity": "sha512-LMTDVMd7T/IfLG59yLWl8Uw2HYGbj2C3jIwkMqH9MBUT5KILK66T3t0yV86SoZJnxZ6xBIJ+kCcCRssCzhvanw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.8.0.tgz",
+			"integrity": "sha512-qQzM32CzJJuniFaTZDspVn/Vtz/PJ/f89+FckLpWZJVWNihgwTHC1/F0YTDH8g6czNw5ZijwQ3xBVuJQYyIXsQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"svgo": "^2.4.0"
 			}
 		},
 		"@parcel/optimizer-terser": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.0.tgz",
-			"integrity": "sha512-oezRt6Lz/QqcVDXyMfFjzQc7n0ThJowLJ4Lyhu8rMh0ZJYzc4UCFCw/19d4nRnzE+Qg0vj3mQCpdkA9/64E44g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.8.0.tgz",
+			"integrity": "sha512-slS6GWQ3u418WtJmlqlA5Njljcq4OaEdDDR2ifEwltG8POv+hsvD5AAoM2XB0GJwY97TQtdMbBu2DuDF3yM/1Q==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"terser": "^5.2.0"
 			}
 		},
 		"@parcel/package-manager": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.0.tgz",
-			"integrity": "sha512-AqFfdkbOw51q/3ia2mIsFTmrpYEyUb3k+2uYC5GsLMz3go6OGn7/Crz0lZLSclv5EtwpRg3TWr9yL7RekVN/Uw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.0.tgz",
+			"integrity": "sha512-n4FgerAX1lTKKTgxmiocnos47Y+b0L60iwU6Q4cC2n4KQNRuNyfhxFXwWcqHstR9wa72JgPaDgo4k0l3Bk8FZw==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"semver": "^5.7.1"
 			}
 		},
 		"@parcel/packager-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.6.0.tgz",
-			"integrity": "sha512-iXUttSe+wtnIM2PKCyFC2I4+Szv+8qHpC3wXeJlXlzd8wljm42y+6Fs4FZ0zihTccRxI2UUhFnKu90ag+5AmjA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.8.0.tgz",
+			"integrity": "sha512-tv/Bto0P6fXjqQ9uCZ8/6b/+38Zr/N2MC7/Nbflzww/lp0k2+kkE9MVJJDr5kST/SzTBRrhbDo+yTbtdZikJYg==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/packager-html": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.6.0.tgz",
-			"integrity": "sha512-HsiXMkU9AJr3LLjsP2Kteho2jCVpabTwcU/fauwbwirhg0xNlRsKxYZRCllRhPkb0FWAnkjzwjOj01MHD6NJCg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.8.0.tgz",
+			"integrity": "sha512-4x09v/bt767rxwGTuEw82CjheoOtIKNu4sx1gqwQOz9QowKPniXOIaD+0XmLiARdzRErucf0sL19QHfNcPAhUw==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5"
 			}
 		},
 		"@parcel/packager-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.0.tgz",
-			"integrity": "sha512-Uz3pqIFchFfKszWnNGDgIwM1uwHHJp7Dts6VzS9lf/2RbRgZT0fmce+NPgnVO5MMKBHzdvm32ShT6gFAABF5Vw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.8.0.tgz",
+			"integrity": "sha512-Tn2EtWM1TEdj4t5pt0QjBDzqrXrfRTL3WsdMipZwDSuX04KS0jedJINHjh46HOMwyfJxLbUg3xkGX7F5mYQj5g==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"globals": "^13.2.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/packager-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.0.tgz",
-			"integrity": "sha512-ktT6Qc/GgCq8H1+6y+AXufVzQj1s6KRoKf83qswCD0iY3MwCbJoEfc3IsB4K64FpHIL5Eu0z54IId+INvGbOYA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.8.0.tgz",
+			"integrity": "sha512-s3VniER3X2oNTlfytBGIQF+UZFVNLFWuVu1IkZ8Wg6uYQffrExDlbNDcmFCDcfvcejL3Ch5igP+L6N00f6+wAQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			}
 		},
 		"@parcel/packager-svg": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.6.0.tgz",
-			"integrity": "sha512-OF2RShyspXu7H4Dn2PmchfMMYPx+kWjOXiYVQ6OkOI0MZmOydx7p8nrcG5+y7vCJTPlta828BSwva0GdKfn46A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.8.0.tgz",
+			"integrity": "sha512-+BSpdPiNjlAne28nOjG2AyiOejAehe/+X9MxL2FIpPP7UBLNc2ekaM0mDTR5iY45YtZa57oyErBT/U6wZ1TCjw==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"posthtml": "^0.16.4"
 			}
 		},
 		"@parcel/packager-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.6.0.tgz",
-			"integrity": "sha512-tXFamEXJXbp6NuVD/SdPLrHj8UqWfGaMgtZGo5dvQp2eyxcjfyKMPS4iZWf8H6tlJPbBK+m26AaSs0QKXMxUuw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-webextension/-/packager-webextension-2.8.0.tgz",
+			"integrity": "sha512-ODB3sTXk/qyivK0JcM+kw9MV5pWigqppIOXQAK5zPv4sYHlMNuZJiANKizs5aP1+9Iz5ludU1wM1qMe1n/xDiw==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/plugin": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.0.tgz",
-			"integrity": "sha512-LzOaiK8R6eFEoov1cb3/W+o0XvXdI/VbDhMDl0L0II+/56M0UeayYtFP5QGTDn/fZqVlYfzPCtt3EMwdG7/dow==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.0.tgz",
+			"integrity": "sha512-Tsf+7nDg7KauvTVY6rGc7CmgJruKSwJ54KJ9s5nYFFP9nfwmyqbayCi9xOxicWU9zIHfuF5Etwf17lcA0oAvzw==",
 			"dev": true,
 			"requires": {
-				"@parcel/types": "2.6.0"
+				"@parcel/types": "2.8.0"
 			}
 		},
 		"@parcel/reporter-cli": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.6.0.tgz",
-			"integrity": "sha512-QFG957NXx3L0D8Zw0+B2j7IHy8f/UzOVu6VvKE3rMkhq/iR2qLrPohQ+uvxlee+CLC0cG2qRSgJ7Ve/rjQPoJg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.8.0.tgz",
+			"integrity": "sha512-ea4/Lp+2jDbzb/tfTgUKzYU51FK8wcewDoYNr06uL+wvx/vzYIDG0jHfzaOTasREnm7ECDr1Zu2Iknrgk1STqQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chalk": "^4.1.0",
 				"term-size": "^2.2.1"
 			}
 		},
 		"@parcel/reporter-dev-server": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.0.tgz",
-			"integrity": "sha512-VvygsCA+uzWyijIV8zqU1gFyhAWknuaY4KIWhV4kCT8afRJwsLSwt/tpdaKDPuPU45h3tTsUdXH1wjaIk+dGeQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.8.0.tgz",
+			"integrity": "sha512-wg6hUrQ8vUmvlP2fg8YEzYndmq7hWZ21ZgBv4So1Z65I+Qav85Uox7bjGLCSJwEAjdjFKfhV9RGULGzqh8vcAQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0"
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0"
 			}
 		},
 		"@parcel/resolver-default": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.0.tgz",
-			"integrity": "sha512-ATk9wXvy5GOHAqyHbnCnU11fUPTtf8dLjpgVqL5XylwugZnyBXbynoTWX4w8h6mffkVtdfmzTJx/o4Lresz9sA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.8.0.tgz",
+			"integrity": "sha512-kO5W+O3Ql6NXNFS6lvfSSt1R+PxO1atNLYxZdVSM6+QQxRMiztfqzZs//RM+oUp+af6muDSUPlNs+RORX0fing==",
 			"dev": true,
 			"requires": {
-				"@parcel/node-resolver-core": "2.6.0",
-				"@parcel/plugin": "2.6.0"
+				"@parcel/node-resolver-core": "2.8.0",
+				"@parcel/plugin": "2.8.0"
 			}
 		},
 		"@parcel/runtime-browser-hmr": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.0.tgz",
-			"integrity": "sha512-90xvv/10cFML5dAhClBEJZ/ExiBQVPqQsZcvRmVZmc5mpZVJMKattWCQrd7pAf7FDYl4JAcvsK3DTwvRT/oLNA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.8.0.tgz",
+			"integrity": "sha512-zV5wGGvm1cDwWAzkwPUaKh6inWYKxq67YWY4G396PXLMxddM9SQC1c7iFM60OPnD4A+BMOLOy7N6//20h15Dlg==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0"
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0"
 			}
 		},
 		"@parcel/runtime-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.0.tgz",
-			"integrity": "sha512-R4tJAIT/SX7VBQ+f7WmeekREQzzLsmgP1j486uKhQNyYrpvsN0HnRbg5aqvZjEjkEmSeJR0mOlWtMK5/m+0yTA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.0.tgz",
+			"integrity": "sha512-IwT1rX8ZamoYZv0clfswZemfXcIfk+YXwNsqXwzzh6TaMGagj/ZZl1llkn7ERQFq4EoLEoDGGkxqsrJjBp9NDQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/runtime-react-refresh": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.0.tgz",
-			"integrity": "sha512-2sRd13gc2EbMV/O5n2NPVGGhKBasb1fDTXGEY8y7qi9xDKc+ewok/D83T+w243FhCPS9Pf3ur5GkbPlrJGcenQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.8.0.tgz",
+			"integrity": "sha512-a6uuZWkl+mJur2WLZKmpEqq1P06tvRwqGefYbE26DWpwXwU9dLpfnv/nT0hqCmVDHd2TkMyCffolSmq1vY05ew==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"react-error-overlay": "6.0.9",
 				"react-refresh": "^0.9.0"
 			}
 		},
 		"@parcel/runtime-service-worker": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.0.tgz",
-			"integrity": "sha512-nVlknGw5J5Bkd1Wr1TbyWHhUd9CmVVebaRg/lpfVKYhAuE/2r+3N0+J8qbEIgtTRcHaSV7wTNpg4weSWq46VeA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.8.0.tgz",
+			"integrity": "sha512-Q3Q2O/axQbFi/5Z+BidLB3qhmYdZLTMDagZtsmyH7CktDkZVNV/0UoOGYlqoK06T4cww3XjLSEomXbBu9TlQKQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/runtime-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.6.0.tgz",
-			"integrity": "sha512-FKdWsSwFktRP1nZxhJwDOmIiEEjVNWk4a96TSC+0baU7IYVHhUZzBu9EtwJdyoJYQr5jyNP2SW3YUrkFFbCYiQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-webextension/-/runtime-webextension-2.8.0.tgz",
+			"integrity": "sha512-pfE30DHlw55GOTxp5k5NkCk2ccgJouF/JtCgHaAJdLqiEoqltsta6yFhHQj9ZLUV1qtjd5MxfIs5xOVXGp8SHw==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/source-map": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-			"integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+			"integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
 			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3"
 			}
 		},
 		"@parcel/transformer-babel": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.6.0.tgz",
-			"integrity": "sha512-qTDzhLoaTpRJoppCNqaAlcUYxcDEvJffem1h3SAQiwvCLUBQowLyeaBy8sUxu54AU6eHFJyBld5ZocENyHTBCA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.8.0.tgz",
+			"integrity": "sha512-ie+wFe9pucdnRyX2PTN9amOHrhr/IOwUEAfTz/3dPydOYCuX7ErEngCpI9fBzdYE2AV6/noEwC2Mjeoyz9mT2A==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
 				"json5": "^2.2.0",
 				"nullthrows": "^1.1.1",
@@ -12853,29 +13105,29 @@
 			}
 		},
 		"@parcel/transformer-css": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.6.0.tgz",
-			"integrity": "sha512-Ei9NPE5Rl9V+MGd8qddfZD0Fsqbvky8J62RwYsqLkptFl9FkhgwOu8Cmokz7IIc4GJ2qzfnG5y54K/Bi7Moq4Q==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.0.tgz",
+			"integrity": "sha512-jCMQSfsxCoepblBAHCYMuNWNPQlqasoD6PfNftMdTlv12aUcnjNIYO9600TVLTL799CrEohljbXcfFn6hDGVWw==",
 			"dev": true,
 			"requires": {
-				"@parcel/css": "^1.9.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
 				"browserslist": "^4.6.6",
+				"lightningcss": "^1.16.1",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/transformer-html": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.6.0.tgz",
-			"integrity": "sha512-YQh5WzNFjPhgV09P+zVS++albTCTvbPYAJXp5zUJ4HavzcpV2IB3HAPRk9x+iXUeRBQYYiO5SMMRkdy9a4CzQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.8.0.tgz",
+			"integrity": "sha512-KLcZCWSIItZ1s12Sav3uvfTrwhX92craN9u7V3qUs8ld7ompTKsCdnf+gYmeCyISb5yiFDyYBvTGc1bOXvaDRQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -12884,28 +13136,29 @@
 			}
 		},
 		"@parcel/transformer-image": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.6.0.tgz",
-			"integrity": "sha512-Zkh1i6nWNOTOReKlZD+bLJCHA16dPLO6Or7ETAHtSF3iRzMNFcVFp+851Awj3l4zeJ6CoCWlyxsR4CEdioRgiQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.8.0.tgz",
+			"integrity": "sha512-hJGsZxGlGEkiUvN8kCxA4DhB6/WrHzcIlZZYEgEien9pLctyc6np6idjdcyudPAhH3LwBPkiyeUfCvLAOA1zkA==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
 				"nullthrows": "^1.1.1"
 			}
 		},
 		"@parcel/transformer-js": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.0.tgz",
-			"integrity": "sha512-4v2r3EVdMKowBziVBW9HZqvAv88HaeiezkWyMX4wAfplo9jBtWEp99KEQINzSEdbXROR81M9oJjlGF5+yoVr/w==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.8.0.tgz",
+			"integrity": "sha512-C5WTkDRiJGBB9tZa1mBsZwsqZjYEKkOa4mdVym3dMokwhFLUga8WtK7kGw4fmXIq41U8ip4orywj+Rd4mvGVWg==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/utils": "2.6.0",
-				"@parcel/workers": "2.6.0",
-				"@swc/helpers": "^0.3.15",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/utils": "2.8.0",
+				"@parcel/workers": "2.8.0",
+				"@swc/helpers": "^0.4.12",
 				"browserslist": "^4.6.6",
 				"detect-libc": "^1.0.3",
 				"nullthrows": "^1.1.1",
@@ -12914,25 +13167,25 @@
 			}
 		},
 		"@parcel/transformer-json": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.0.tgz",
-			"integrity": "sha512-zb+TQAdHWdXijKcFhLe+5KN1O0IzXwW1gJhPr8DJEA3qhPaCsncsw5RCVjQlP3a7NXr1mMm1eMtO6bhIMqbXeA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.8.0.tgz",
+			"integrity": "sha512-Pp5gROSMpzFDEI6KA2APuSpft6eXZxFgTPV6Xx9pElqseod3iL5+RnpMNV/nv76Ai2bcMEiafus5Pb09vjHgbQ==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
+				"@parcel/plugin": "2.8.0",
 				"json5": "^2.2.0"
 			}
 		},
 		"@parcel/transformer-postcss": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.6.0.tgz",
-			"integrity": "sha512-czmh2mOPJLwYbtnPTFlxKYcaQHH6huIlpfNX1XgdsaEYS+yFs8ZXpzqjxI1wu6rMW0R0q5aon72yB3PJewvqNQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.8.0.tgz",
+			"integrity": "sha512-45Ij+cgwXprd1sCLmaMIlCbPz3eEwolGHizgZmXl5l4yjlE2wGyzodhxLpBk1PWu7OxxWRbLnJIlvMYf7Vfw0g==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"clone": "^2.1.1",
 				"nullthrows": "^1.1.1",
 				"postcss-value-parser": "^4.2.0",
@@ -12940,13 +13193,13 @@
 			}
 		},
 		"@parcel/transformer-posthtml": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.6.0.tgz",
-			"integrity": "sha512-R1FmPMZ0pgrbPZkDppa2pE+6KDK3Wxof6uQo7juHLB2ELGOTaYofsG3nrRdk+chyAHaVv4qWLqXbfZK6pGepEg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.0.tgz",
+			"integrity": "sha512-KrkKBFDW5PNZpr2Ha711eIABQOiJQKvfwfVs3CVpJK5wSADkappDk7CQ0mISPjhamFJ6xx/sNsi7e871I8R9lg==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -12955,34 +13208,34 @@
 			}
 		},
 		"@parcel/transformer-raw": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.0.tgz",
-			"integrity": "sha512-QDirlWCS/qy0DQ3WvDIAnFP52n1TJW/uWH+4PGMNnX4/M3/2UchY8xp9CN0tx4NQ4g09S8o3gLlHvNxQqZxFrQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.8.0.tgz",
+			"integrity": "sha512-uEbj+kE70vg2Gmdji/AIXPK13s5aQRw7X+xWs3vNpY2oymyMRHbfx1izJFWBh+kxu6Yo6q6qsekkh2rNHEHIUA==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0"
+				"@parcel/plugin": "2.8.0"
 			}
 		},
 		"@parcel/transformer-react-refresh-wrap": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.0.tgz",
-			"integrity": "sha512-G34orfvLDUTumuerqNmA8T8NUHk+R0jwUjbVPO7gpB6VCVQ5ocTABdE9vN9Uu/cUsHij40TUFwqK4R9TFEBIEQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.8.0.tgz",
+			"integrity": "sha512-d7G6wBdlwVXLkhC7EO/3UkUOfEOJvsIsQUCEujsrdFF+nfBElXw/TZ+KP8UkmrwMdD0spU/8cKoTyi5k19vt6w==",
 			"dev": true,
 			"requires": {
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"react-refresh": "^0.9.0"
 			}
 		},
 		"@parcel/transformer-svg": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.6.0.tgz",
-			"integrity": "sha512-e7yrb7775A7tEGRsAHQSMhXe+u4yisH5W0PuIzAQQy/a2IwBjaSxNnvyelN7tNX0FYq0BK6An5wRbhK4YmM+xw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.8.0.tgz",
+			"integrity": "sha512-8S6yZoUTCbHOnuWY3M50fscTpI8414945I44fmed+C1e36TnWem8FifuVtGkRZeR8pokF453lmmwWG1eH/4U3w==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/plugin": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/plugin": "2.8.0",
 				"nullthrows": "^1.1.1",
 				"posthtml": "^0.16.5",
 				"posthtml-parser": "^0.10.1",
@@ -12991,52 +13244,52 @@
 			}
 		},
 		"@parcel/transformer-webextension": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.6.0.tgz",
-			"integrity": "sha512-Yp0Pwi/CPLBdK6joiDne0CEOCikfPkK+3VtL2AoCynvshwC4gZIXoR8jOKimvXfmNZTvZIN6WzpRN0ryGvpz2A==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-webextension/-/transformer-webextension-2.8.0.tgz",
+			"integrity": "sha512-pGxATimkO7r8JbSysDD45YMmDvk4Tk2AHRQs5mLU/y7QwpT6d8zI30W4+ZpgDqx52Ih5BB2RlaGV1gZeLlpXqg==",
 			"dev": true,
 			"requires": {
 				"@mischnic/json-sourcemap": "^0.1.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/plugin": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/plugin": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"content-security-policy-parser": "^0.3.0"
 			}
 		},
 		"@parcel/types": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.0.tgz",
-			"integrity": "sha512-lAMYvOBfNEJMsPJ+plbB50305o0TwNrY1xX5RRIWBqwOa6bYmbW1ZljUk1tQvnkpIE4eAHQwnPR5Z2XWg18wGQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.0.tgz",
+			"integrity": "sha512-DeN3vCnVl9onjtyWxpbP7LwRslVEko4kBaM7yILsuQjEnXmaIOsqIf6FQJOUOPBtQTFFNeQQ2qyf5XoO/rkJ8g==",
 			"dev": true,
 			"requires": {
-				"@parcel/cache": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
-				"@parcel/workers": "2.6.0",
+				"@parcel/cache": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
+				"@parcel/workers": "2.8.0",
 				"utility-types": "^3.10.0"
 			}
 		},
 		"@parcel/utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.0.tgz",
-			"integrity": "sha512-ElXz+QHtT1JQIucbQJBk7SzAGoOlBp4yodEQVvTKS7GA+hEGrSP/cmibl6qm29Rjtd0zgQsdd+2XmP3xvP2gQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.0.tgz",
+			"integrity": "sha512-r4ACsGtW7zkMUIgwQyOVtPAFiy8L81gbz4tMIRSqyQKnkW7oEHcQ3uN1/LPxj2yfkyQLmhJxmtptLUy9j53rcw==",
 			"dev": true,
 			"requires": {
-				"@parcel/codeframe": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/hash": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/markdown-ansi": "2.6.0",
-				"@parcel/source-map": "^2.0.0",
+				"@parcel/codeframe": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/hash": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/markdown-ansi": "2.8.0",
+				"@parcel/source-map": "^2.1.1",
 				"chalk": "^4.1.0"
 			}
 		},
 		"@parcel/watcher": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-			"integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.7.tgz",
+			"integrity": "sha512-gc3hoS6e+2XdIQ4HHljDB1l0Yx2EWh/sBBtCEFNKGSMlwASWeAQsOY/fPbxOBcZ/pg0jBh4Ga+4xHlZc4faAEQ==",
 			"dev": true,
 			"requires": {
 				"node-addon-api": "^3.2.1",
@@ -13044,15 +13297,15 @@
 			}
 		},
 		"@parcel/workers": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.0.tgz",
-			"integrity": "sha512-3tcI2LF5fd/WZtSnSjyWdDE+G+FitdNrRgSObzSp+axHKMAM23sO0z7KY8s2SYCF40msdYbFUW8eI6JlYNJoWQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.0.tgz",
+			"integrity": "sha512-vAzoC/wPHLQnyy9P/TrSPftY8F3MhZqPTFi681mxVtLWA3t7wiNlw1zDVKRDP8m5XS1yQOr8Q56CAHyRexhc8g==",
 			"dev": true,
 			"requires": {
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/types": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/types": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chrome-trace-event": "^1.0.2",
 				"nullthrows": "^1.1.1"
 			}
@@ -13109,9 +13362,9 @@
 			}
 		},
 		"@swc/helpers": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
-			"integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+			"integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.4.0"
@@ -13165,9 +13418,9 @@
 			}
 		},
 		"@types/chrome": {
-			"version": "0.0.190",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.190.tgz",
-			"integrity": "sha512-lCwwIBfaD+PhG62qFB46mIBpD+xBIa+PedNB24KR9YnmJ0Zn9h0OwP1NQBhI8Cbu1rKwTQHTxhs7GhWGyUvinw==",
+			"version": "0.0.203",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.203.tgz",
+			"integrity": "sha512-JlQNebwpBETVc8U1Rr2inDFuOTtn0lahRAhnddx1dd0S5RrLAFJEEsyIu7AXI14mkCgSunksnuLGioH8kvBqRA==",
 			"dev": true,
 			"requires": {
 				"@types/filesystem": "*",
@@ -13513,9 +13766,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true
 		},
 		"acorn-import-assertions": {
@@ -13852,9 +14105,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -13885,27 +14138,27 @@
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
+			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
+				"camelcase": "^7.0.0",
+				"map-obj": "^4.3.0",
+				"quick-lru": "^6.1.1",
+				"type-fest": "^2.13.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+					"integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
 					"dev": true
 				},
 				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 					"dev": true
 				}
 			}
@@ -13945,9 +14198,9 @@
 			"dev": true
 		},
 		"ci-info": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-			"integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 			"dev": true
 		},
 		"cjs-module-lexer": {
@@ -14036,10 +14289,10 @@
 			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
 			"dev": true
 		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+		"common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
 			"dev": true
 		},
 		"concat-map": {
@@ -14088,9 +14341,9 @@
 			}
 		},
 		"cosmiconfig": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
@@ -14178,15 +14431,15 @@
 			}
 		},
 		"decamelize": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
 			"dev": true
 		},
 		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -14479,13 +14732,15 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-			"integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+			"version": "8.28.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+			"integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.9.2",
+				"@eslint/eslintrc": "^1.3.3",
+				"@humanwhocodes/config-array": "^0.11.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -14495,18 +14750,21 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
 				"globals": "^13.15.0",
+				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -14517,8 +14775,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"argparse": {
@@ -14533,6 +14790,16 @@
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
 				},
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"js-yaml": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -14540,6 +14807,33 @@
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
 					}
 				}
 			}
@@ -14552,9 +14846,9 @@
 			"requires": {}
 		},
 		"eslint-config-xo": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.41.0.tgz",
-			"integrity": "sha512-cyTc182COQVdalOi5105h0Cw/Qb52IRGyIZLmUICIauANm9Upmv81UEsuFkdKnvwr4NtU95qjdk3g4/kNspA6g==",
+			"version": "0.43.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.43.1.tgz",
+			"integrity": "sha512-azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==",
 			"dev": true,
 			"requires": {
 				"confusing-browser-globals": "1.0.11"
@@ -14860,25 +15154,25 @@
 			}
 		},
 		"eslint-plugin-n": {
-			"version": "15.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.2.tgz",
-			"integrity": "sha512-MLjZVAv4TiCIoXqjibNqCJjLkGHfrOY3XZ0ZBLoW0OnS3o98PUBnzB/kfp8dCz/4A4Y18jjX50PRnqI4ACFY1Q==",
+			"version": "15.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.5.1.tgz",
+			"integrity": "sha512-kAd+xhZm7brHoFLzKLB7/FGRFJNg/srmv67mqb7tto22rpr4wv/LV6RuXzAfv3jbab7+k1wi42PsIhGviywaaw==",
 			"dev": true,
 			"requires": {
 				"builtins": "^5.0.1",
 				"eslint-plugin-es": "^4.1.0",
 				"eslint-utils": "^3.0.0",
 				"ignore": "^5.1.1",
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.11.0",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.10.1",
-				"semver": "^7.3.7"
+				"resolve": "^1.22.1",
+				"semver": "^7.3.8"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -14899,40 +15193,40 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-			"integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
 			}
 		},
 		"eslint-plugin-unicorn": {
-			"version": "42.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz",
-			"integrity": "sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==",
+			"version": "44.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+			"integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"ci-info": "^3.3.0",
+				"@babel/helper-validator-identifier": "^7.19.1",
+				"ci-info": "^3.4.0",
 				"clean-regexp": "^1.0.0",
 				"eslint-utils": "^3.0.0",
 				"esquery": "^1.4.0",
 				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.1.0",
+				"is-builtin-module": "^3.2.0",
 				"lodash": "^4.17.21",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
 				"regexp-tree": "^0.1.24",
 				"safe-regex": "^2.1.1",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"strip-indent": "^3.0.0"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -14980,22 +15274,22 @@
 			"dev": true
 		},
 		"esm-utils": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.0.0.tgz",
-			"integrity": "sha512-1x5H25/8BQWV94T8+KRb1gcSdVQ3g+8P0NikggAujVaurUa0cOoR+UO8ie3y29iQO70HjNA93c9ie+qqI/8zzw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.1.1.tgz",
+			"integrity": "sha512-cTy4OQgEP/yc7RY3s6EgwMGZ10gAPhCLE9FcrQ6/5bhf37o9PZCFSjzQR1tYb4GaKAEMaW1UmDcMZR13H4p6LQ==",
 			"dev": true,
 			"requires": {
-				"import-meta-resolve": "1.1.1",
+				"import-meta-resolve": "2.2.0",
 				"url-or-path": "2.1.0"
 			}
 		},
 		"espree": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-			"integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.3.0"
 			}
@@ -15217,14 +15511,73 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+			"integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^7.1.0",
+						"path-exists": "^5.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
+					"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^6.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^4.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+					"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^6.3.0"
+					}
+				},
+				"yocto-queue": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+					"dev": true
+				}
 			}
 		},
 		"find-file-up": {
@@ -15352,12 +15705,6 @@
 				"es-abstract": "^1.19.0",
 				"functions-have-names": "^1.2.2"
 			}
-		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
 		},
 		"functions-have-names": {
 			"version": "1.2.3",
@@ -15527,6 +15874,12 @@
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
+		"grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
 		"hard-rejection": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -15588,12 +15941,20 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.5.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "7.14.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+					"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+					"dev": true
+				}
 			}
 		},
 		"html-escaper": {
@@ -15603,9 +15964,9 @@
 			"dev": true
 		},
 		"htmlnano": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-			"integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.3.tgz",
+			"integrity": "sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^7.0.1",
@@ -15674,33 +16035,10 @@
 			}
 		},
 		"import-meta-resolve": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-1.1.1.tgz",
-			"integrity": "sha512-JiTuIvVyPaUg11eTrNDx5bgQ/yMKMZffc7YSjvQeSMXy58DO2SQ8BtAf3xteZvmzvjYh14wnqNjL8XVeDy2o9A==",
-			"dev": true,
-			"requires": {
-				"builtins": "^4.0.0"
-			},
-			"dependencies": {
-				"builtins": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/builtins/-/builtins-4.1.0.tgz",
-					"integrity": "sha512-1bPRZQtmKaO6h7qV1YHXNtr6nCK28k0Zo95KM4dXfILcZZwoHJBN1m3lfLv9LPkcOZlrSr+J1bzMaZFO98Yq0w==",
-					"dev": true,
-					"requires": {
-						"semver": "^7.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.0.tgz",
+			"integrity": "sha512-CpPOtiCHxP9HdtDM5F45tNiAe66Cqlv3f5uHoJjt+KlaLrUh9/Wz9vepADZ78SlqEo62aDWZtj9ydMGXV+CPnw==",
+			"dev": true
 		},
 		"import-modules": {
 			"version": "2.1.0",
@@ -15815,12 +16153,12 @@
 			"dev": true
 		},
 		"is-builtin-module": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+			"integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^3.0.0"
+				"builtin-modules": "^3.3.0"
 			}
 		},
 		"is-callable": {
@@ -15830,9 +16168,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -15947,6 +16285,12 @@
 				"lowercase-keys": "^1.0.0",
 				"obj-props": "^1.0.0"
 			}
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -16760,6 +17104,12 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
+		"js-sdsl": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+			"integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+			"dev": true
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16849,6 +17199,79 @@
 				"type-check": "~0.4.0"
 			}
 		},
+		"lightningcss": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.1.tgz",
+			"integrity": "sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==",
+			"dev": true,
+			"requires": {
+				"detect-libc": "^1.0.3",
+				"lightningcss-darwin-arm64": "1.16.1",
+				"lightningcss-darwin-x64": "1.16.1",
+				"lightningcss-linux-arm-gnueabihf": "1.16.1",
+				"lightningcss-linux-arm64-gnu": "1.16.1",
+				"lightningcss-linux-arm64-musl": "1.16.1",
+				"lightningcss-linux-x64-gnu": "1.16.1",
+				"lightningcss-linux-x64-musl": "1.16.1",
+				"lightningcss-win32-x64-msvc": "1.16.1"
+			}
+		},
+		"lightningcss-darwin-arm64": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.1.tgz",
+			"integrity": "sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-darwin-x64": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.1.tgz",
+			"integrity": "sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-linux-arm-gnueabihf": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.1.tgz",
+			"integrity": "sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-linux-arm64-gnu": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.1.tgz",
+			"integrity": "sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-linux-arm64-musl": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.1.tgz",
+			"integrity": "sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-linux-x64-gnu": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.1.tgz",
+			"integrity": "sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-linux-x64-musl": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.1.tgz",
+			"integrity": "sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==",
+			"dev": true,
+			"optional": true
+		},
+		"lightningcss-win32-x64-msvc": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.1.tgz",
+			"integrity": "sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==",
+			"dev": true,
+			"optional": true
+		},
 		"line-column-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-3.0.0.tgz",
@@ -16873,21 +17296,20 @@
 			"dev": true
 		},
 		"lmdb": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
-			"integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+			"integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
 			"dev": true,
 			"requires": {
-				"lmdb-darwin-arm64": "2.3.10",
-				"lmdb-darwin-x64": "2.3.10",
-				"lmdb-linux-arm": "2.3.10",
-				"lmdb-linux-arm64": "2.3.10",
-				"lmdb-linux-x64": "2.3.10",
-				"lmdb-win32-x64": "2.3.10",
+				"@lmdb/lmdb-darwin-arm64": "2.5.2",
+				"@lmdb/lmdb-darwin-x64": "2.5.2",
+				"@lmdb/lmdb-linux-arm": "2.5.2",
+				"@lmdb/lmdb-linux-arm64": "2.5.2",
+				"@lmdb/lmdb-linux-x64": "2.5.2",
+				"@lmdb/lmdb-win32-x64": "2.5.2",
 				"msgpackr": "^1.5.4",
-				"nan": "^2.14.2",
 				"node-addon-api": "^4.3.0",
-				"node-gyp-build-optional-packages": "^4.3.2",
+				"node-gyp-build-optional-packages": "5.0.3",
 				"ordered-binary": "^1.2.4",
 				"weak-lru-cache": "^1.2.2"
 			},
@@ -16899,48 +17321,6 @@
 					"dev": true
 				}
 			}
-		},
-		"lmdb-darwin-arm64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
-			"integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
-			"dev": true,
-			"optional": true
-		},
-		"lmdb-darwin-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
-			"integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
-			"dev": true,
-			"optional": true
-		},
-		"lmdb-linux-arm": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
-			"integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
-			"dev": true,
-			"optional": true
-		},
-		"lmdb-linux-arm64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
-			"integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
-			"dev": true,
-			"optional": true
-		},
-		"lmdb-linux-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
-			"integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
-			"dev": true,
-			"optional": true
-		},
-		"lmdb-win32-x64": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
-			"integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
-			"dev": true,
-			"optional": true
 		},
 		"loader-runner": {
 			"version": "4.3.0",
@@ -17046,89 +17426,147 @@
 			"dev": true
 		},
 		"meow": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
-			"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
+			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
+				"camelcase-keys": "^8.0.2",
+				"decamelize": "^6.0.0",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
 				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
+				"normalize-package-data": "^4.0.1",
+				"read-pkg-up": "^9.1.0",
 				"redent": "^4.0.0",
 				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
+				"type-fest": "^3.1.0",
+				"yargs-parser": "^21.1.1"
 			},
 			"dependencies": {
 				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
+						"locate-path": "^7.1.0",
+						"path-exists": "^5.0.0"
+					}
+				},
+				"hosted-git-info": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
+					"integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^5.0.0"
+						"p-locate": "^6.0.0"
 					}
 				},
 				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
 					"dev": true,
 					"requires": {
-						"yocto-queue": "^0.1.0"
+						"yocto-queue": "^1.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^3.0.2"
+						"p-limit": "^4.0.0"
 					}
 				},
+				"path-exists": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+					"dev": true
+				},
 				"read-pkg": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+					"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
 					"dev": true,
 					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
+						"@types/normalize-package-data": "^2.4.1",
 						"normalize-package-data": "^3.0.2",
 						"parse-json": "^5.2.0",
-						"type-fest": "^1.0.1"
+						"type-fest": "^2.0.0"
+					},
+					"dependencies": {
+						"normalize-package-data": {
+							"version": "3.0.3",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+							"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^4.0.1",
+								"is-core-module": "^2.5.0",
+								"semver": "^7.3.4",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"type-fest": {
+							"version": "2.19.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+							"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+							"dev": true
+						}
 					}
 				},
 				"read-pkg-up": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+					"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
 					"dev": true,
 					"requires": {
-						"find-up": "^5.0.0",
-						"read-pkg": "^6.0.0",
-						"type-fest": "^1.0.1"
+						"find-up": "^6.3.0",
+						"read-pkg": "^7.1.0",
+						"type-fest": "^2.5.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "2.19.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+							"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+							"dev": true
+						}
+					}
+				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
 					}
 				},
 				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
+					"integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
+					"dev": true
+				},
+				"yocto-queue": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
 					"dev": true
 				}
 			}
@@ -17305,12 +17743,6 @@
 				}
 			}
 		},
-		"nan": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-			"integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-			"dev": true
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17340,15 +17772,15 @@
 			}
 		},
 		"node-gyp-build": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-			"integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
 			"dev": true
 		},
 		"node-gyp-build-optional-packages": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
-			"integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+			"integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
 			"dev": true
 		},
 		"node-int64": {
@@ -17364,21 +17796,21 @@
 			"dev": true
 		},
 		"normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "^5.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -17521,9 +17953,9 @@
 			}
 		},
 		"ordered-binary": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.5.tgz",
-			"integrity": "sha512-djRmZoEpOGvIRW7ufsCDHtvcUa18UC9TxnPbHhSVFZHsoyg0dtut1bWtBZ/fmxdPN62oWXrV6adM7NoWU+CneA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
+			"integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
 			"dev": true
 		},
 		"os-homedir": {
@@ -17557,21 +17989,21 @@
 			"dev": true
 		},
 		"parcel": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/parcel/-/parcel-2.6.0.tgz",
-			"integrity": "sha512-pSTJ7wC6uTl16PKLXQV7RfL9FGoIDA1iVpNvaav47n6UkUdKqfx0spcVPpw35kWdRcHJF61YAvkPjP2hTwHQ+Q==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/parcel/-/parcel-2.8.0.tgz",
+			"integrity": "sha512-p7Fo75CeMw5HC1luovYpBjzPbAJv/Gn7lxcs4f0LxcwBCWbkQ73zHgJXJQqnM38qQABEYEiQq6000+j+k5U/Mw==",
 			"dev": true,
 			"requires": {
-				"@parcel/config-default": "2.6.0",
-				"@parcel/core": "2.6.0",
-				"@parcel/diagnostic": "2.6.0",
-				"@parcel/events": "2.6.0",
-				"@parcel/fs": "2.6.0",
-				"@parcel/logger": "2.6.0",
-				"@parcel/package-manager": "2.6.0",
-				"@parcel/reporter-cli": "2.6.0",
-				"@parcel/reporter-dev-server": "2.6.0",
-				"@parcel/utils": "2.6.0",
+				"@parcel/config-default": "2.8.0",
+				"@parcel/core": "2.8.0",
+				"@parcel/diagnostic": "2.8.0",
+				"@parcel/events": "2.8.0",
+				"@parcel/fs": "2.8.0",
+				"@parcel/logger": "2.8.0",
+				"@parcel/package-manager": "2.8.0",
+				"@parcel/reporter-cli": "2.8.0",
+				"@parcel/reporter-dev-server": "2.8.0",
+				"@parcel/utils": "2.8.0",
 				"chalk": "^4.1.0",
 				"commander": "^7.0.0",
 				"get-port": "^4.2.0",
@@ -17743,9 +18175,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
-			"integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+			"integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -17848,9 +18280,9 @@
 			"dev": true
 		},
 		"quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+			"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
 			"dev": true
 		},
 		"randombytes": {
@@ -17977,9 +18409,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"dev": true
 		},
 		"regexp-tree": {
@@ -18012,12 +18444,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.8.1",
+				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -18264,9 +18696,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -18682,9 +19114,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -18829,9 +19261,9 @@
 			}
 		},
 		"webext-content-scripts": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-1.0.2.tgz",
-			"integrity": "sha512-gC+afnJFmsjBxtJAkG1bEUGnpedVMJq2wqEpswrZTuC3T4sAozkeJvC4GdZ/SjKDvj+HR0qcIQqVCWmlCv96DQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-1.0.3.tgz",
+			"integrity": "sha512-Kwd6V/Dbbfl136e30aXd319IZPy3TvgKqqF834vlkOp/ALzEE8caPEbbjGHSQjt/zJVr3vtlUQOWP7GUH8WJlA==",
 			"requires": {
 				"webext-polyfill-kinda": "^0.10.0"
 			}
@@ -19003,47 +19435,47 @@
 			"requires": {}
 		},
 		"xo": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.50.0.tgz",
-			"integrity": "sha512-yIz7mdIbUlxBYLnV3OqMTdrE+OFr0CPINkU9rxY3ZHNAIZrVckmONLujU6LkdNrEWerQTx8zzwnVrUjmj6vVCg==",
+			"version": "0.53.1",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.53.1.tgz",
+			"integrity": "sha512-/2R8SPehv1UhiIqJ9uSvrAjslcoygICNsUlEb/Zf2V6rMtr7YCoggc6hlt6b/kbncpR989Roqt6AvEO779dFxw==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@typescript-eslint/eslint-plugin": "*",
-				"@typescript-eslint/parser": "*",
+				"@eslint/eslintrc": "^1.3.3",
+				"@typescript-eslint/eslint-plugin": "^5.43.0",
+				"@typescript-eslint/parser": "^5.43.0",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^7.0.1",
+				"cosmiconfig": "^7.1.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.17.0",
+				"eslint": "^8.27.0",
 				"eslint-config-prettier": "^8.5.0",
-				"eslint-config-xo": "^0.41.0",
-				"eslint-config-xo-typescript": "*",
+				"eslint-config-xo": "^0.43.1",
+				"eslint-config-xo-typescript": "^0.55.0",
 				"eslint-formatter-pretty": "^4.1.0",
 				"eslint-import-resolver-webpack": "^0.13.2",
 				"eslint-plugin-ava": "^13.2.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-import": "^2.26.0",
-				"eslint-plugin-n": "^15.2.2",
+				"eslint-plugin-n": "^15.5.1",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-prettier": "^4.0.0",
-				"eslint-plugin-unicorn": "^42.0.0",
-				"esm-utils": "^4.0.0",
-				"find-cache-dir": "^3.3.2",
+				"eslint-plugin-prettier": "^4.2.1",
+				"eslint-plugin-unicorn": "^44.0.2",
+				"esm-utils": "^4.1.0",
+				"find-cache-dir": "^4.0.0",
 				"find-up": "^6.3.0",
 				"get-stdin": "^9.0.0",
-				"globby": "^13.1.1",
+				"globby": "^13.1.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"json5": "^2.2.1",
 				"lodash-es": "^4.17.21",
-				"meow": "^10.1.2",
+				"meow": "^11.0.0",
 				"micromatch": "^4.0.5",
 				"open-editor": "^4.0.0",
-				"prettier": "^2.6.2",
-				"semver": "^7.3.7",
-				"slash": "^4.0.0",
+				"prettier": "^2.7.1",
+				"semver": "^7.3.8",
+				"slash": "^5.0.0",
 				"to-absolute-glob": "^2.0.2",
-				"typescript": "^4.7.3"
+				"typescript": "^4.9.3"
 			},
 			"dependencies": {
 				"@nodelib/fs.scandir": {
@@ -19074,64 +19506,70 @@
 					"bundled": true,
 					"dev": true
 				},
+				"@types/semver": {
+					"version": "7.3.13",
+					"bundled": true,
+					"dev": true
+				},
 				"@typescript-eslint/eslint-plugin": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/scope-manager": "5.27.1",
-						"@typescript-eslint/type-utils": "5.27.1",
-						"@typescript-eslint/utils": "5.27.1",
+						"@typescript-eslint/scope-manager": "5.43.0",
+						"@typescript-eslint/type-utils": "5.43.0",
+						"@typescript-eslint/utils": "5.43.0",
 						"debug": "^4.3.4",
-						"functional-red-black-tree": "^1.0.1",
 						"ignore": "^5.2.0",
+						"natural-compare-lite": "^1.4.0",
 						"regexpp": "^3.2.0",
 						"semver": "^7.3.7",
 						"tsutils": "^3.21.0"
 					}
 				},
 				"@typescript-eslint/parser": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/scope-manager": "5.27.1",
-						"@typescript-eslint/types": "5.27.1",
-						"@typescript-eslint/typescript-estree": "5.27.1",
+						"@typescript-eslint/scope-manager": "5.43.0",
+						"@typescript-eslint/types": "5.43.0",
+						"@typescript-eslint/typescript-estree": "5.43.0",
 						"debug": "^4.3.4"
 					}
 				},
 				"@typescript-eslint/scope-manager": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.27.1",
-						"@typescript-eslint/visitor-keys": "5.27.1"
+						"@typescript-eslint/types": "5.43.0",
+						"@typescript-eslint/visitor-keys": "5.43.0"
 					}
 				},
 				"@typescript-eslint/type-utils": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/utils": "5.27.1",
+						"@typescript-eslint/typescript-estree": "5.43.0",
+						"@typescript-eslint/utils": "5.43.0",
 						"debug": "^4.3.4",
 						"tsutils": "^3.21.0"
 					}
 				},
 				"@typescript-eslint/types": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.27.1",
-						"@typescript-eslint/visitor-keys": "5.27.1",
+						"@typescript-eslint/types": "5.43.0",
+						"@typescript-eslint/visitor-keys": "5.43.0",
 						"debug": "^4.3.4",
 						"globby": "^11.1.0",
 						"is-glob": "^4.0.3",
@@ -19160,24 +19598,26 @@
 					}
 				},
 				"@typescript-eslint/utils": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@types/json-schema": "^7.0.9",
-						"@typescript-eslint/scope-manager": "5.27.1",
-						"@typescript-eslint/types": "5.27.1",
-						"@typescript-eslint/typescript-estree": "5.27.1",
+						"@types/semver": "^7.3.12",
+						"@typescript-eslint/scope-manager": "5.43.0",
+						"@typescript-eslint/types": "5.43.0",
+						"@typescript-eslint/typescript-estree": "5.43.0",
 						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0"
+						"eslint-utils": "^3.0.0",
+						"semver": "^7.3.7"
 					}
 				},
 				"@typescript-eslint/visitor-keys": {
-					"version": "5.27.1",
+					"version": "5.43.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@typescript-eslint/types": "5.27.1",
+						"@typescript-eslint/types": "5.43.0",
 						"eslint-visitor-keys": "^3.3.0"
 					}
 				},
@@ -19218,7 +19658,7 @@
 					}
 				},
 				"eslint-config-xo-typescript": {
-					"version": "0.51.1",
+					"version": "0.55.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {}
@@ -19273,7 +19713,7 @@
 					"dev": true
 				},
 				"fast-glob": {
-					"version": "3.2.11",
+					"version": "3.2.12",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -19309,11 +19749,6 @@
 						"locate-path": "^7.1.0",
 						"path-exists": "^5.0.0"
 					}
-				},
-				"functional-red-black-tree": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
 				},
 				"glob-parent": {
 					"version": "5.1.2",
@@ -19355,14 +19790,6 @@
 						"p-locate": "^6.0.0"
 					}
 				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"merge2": {
 					"version": "1.4.1",
 					"bundled": true,
@@ -19376,6 +19803,11 @@
 						"braces": "^3.0.2",
 						"picomatch": "^2.3.1"
 					}
+				},
+				"natural-compare-lite": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "4.0.0",
@@ -19435,17 +19867,27 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
+					"version": "7.3.8",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
 					}
 				},
 				"slash": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-5.0.0.tgz",
+					"integrity": "sha512-n6KkmvKS0623igEVj3FF0OZs1gYYJ0o0Hj939yc1fyxl2xt+xYpLnzJB6xBSqOfV9ZFLEWodBBN/heZJahuIJQ==",
 					"dev": true
 				},
 				"to-regex-range": {
@@ -19519,20 +19961,12 @@
 				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^21.0.0"
-			},
-			"dependencies": {
-				"yargs-parser": {
-					"version": "21.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-					"dev": true
-				}
 			}
 		},
 		"yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true
 		},
 		"yauzl": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,11 @@
 		"rules": {
 			"no-implicit-globals": "off",
 			"@typescript-eslint/prefer-nullish-coalescing": "off",
+			"@typescript-eslint/no-implicit-any-catch": "off",
 			"import/extensions": "off",
 			"import/no-unassigned-import": "off",
+			"unicorn/prefer-top-level-await": "off",
+			"unicorn/prefer-node-protocol": "off",
 			"n/file-extension-in-import": "off"
 		}
 	},
@@ -58,19 +61,19 @@
 	"dependencies": {
 		"content-scripts-register-polyfill": "^3.2.2",
 		"webext-additional-permissions": "^2.3.0",
-		"webext-content-scripts": "^1.0.2"
+		"webext-content-scripts": "^1.0.3"
 	},
 	"devDependencies": {
-		"@parcel/config-webextension": "^2.6.0",
+		"@parcel/config-webextension": "^2.8.0",
 		"@sindresorhus/tsconfig": "^3.0.1",
-		"@types/chrome": "^0.0.190",
+		"@types/chrome": "^0.0.203",
 		"@types/firefox-webext-browser": "^94.0.1",
 		"jest": "^28.1.1",
 		"jest-puppeteer": "^6.1.0",
-		"parcel": "^2.6.0",
+		"parcel": "^2.8.0",
 		"puppeteer": "^14.4.0",
-		"typescript": "^4.7.3",
-		"xo": "^0.50.0"
+		"typescript": "^4.9.3",
+		"xo": "^0.53.1"
 	},
 	"alias": {
 		"these-are-just-mocks-for-parcel-tests": "yolo",
@@ -102,7 +105,9 @@
 		"run": {
 			"startUrl": [
 				"https://iframe-test-page.vercel.app/",
-				"https://iframe-test-page.vercel.app/cross-origin-parent.html"
+				"https://iframe-test-page.vercel.app/cross-origin-parent.html",
+				"https://iframe-test-page-n786423ca-fregante.vercel.app/",
+				"https://iframe-test-page-n786423ca-fregante.vercel.app/cross-origin-parent.html"
 			]
 		}
 	}

--- a/test/demo-extension/mv2/content.js
+++ b/test/demo-extension/mv2/content.js
@@ -1,5 +1,14 @@
 document.body.insertAdjacentHTML(
 	'beforeEnd',
-	'<p class="web-ext">Content script loaded',
+	`
+		<p class="web-ext" style="
+			padding: 4px;
+			font-size: 20px;
+			background: cornflowerblue;
+			display: inline-block;
+		">
+			Content script loaded
+		</p>
+	`,
 );
 console.log('Content script loaded', new Date());

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ const expect = puppeteer.default;
 
 async function expectToNotMatchElement(window, selector) {
 	try {
-		await expect(window).toMatchElement('lol');
+		await expect(window).toMatchElement(selector);
 		throw new Error(`Unexpected "${selector}" element found`);
 	} catch (error) {
 		if (!error.message.startsWith(`Element ${selector} not found`)) {

--- a/test/test.js
+++ b/test/test.js
@@ -9,8 +9,8 @@ const expect = puppeteer.default;
 
 async function expectToNotMatchElement(window, selector) {
 	try {
-		await expect(window).toMatchElement(selector);
-		throw new Error(`Expected ${selector} element found`);
+		await expect(window).toMatchElement('lol');
+		throw new Error(`Unexpected "${selector}" element found`);
 	} catch (error) {
 		if (!error.message.startsWith(`Element ${selector} not found`)) {
 			throw error.message;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"outDir": ".",
-		"target": "es2019",
-		"module": "es2015",
-		"moduleResolution": "node"
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "node",
 	},
 	"files": [
 		"global.d.ts",


### PR DESCRIPTION
Updates avoided:

- jest / puppeteer
	- https://github.com/smooth-code/jest-puppeteer/issues/495
- content-scripts-register-polyfill@4
	- 	https://github.com/fregante/content-scripts-register-polyfill/commit/46794bacdc673e6ed40c463f5ffe952e382ecf1d

---

Ironically the polyfill’s previous behavior worked better for this logic because Chrome _does_ deduplicate static content script files, even if they appear multiple times in the same manifest.

This was [changed](https://github.com/fregante/content-scripts-register-polyfill/commit/46794bacdc673e6ed40c463f5ffe952e382ecf1d) because `contentScripts.register` does not.

At this point I don’t think it's worth working on the polyfill any further because it's essentially only needed in Chrome MV2. See findings in https://github.com/fregante/content-scripts-register-polyfill/issues/11#issuecomment-1157679839