### PR TITLE
Drop overlapping permissions

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -1,4 +1,4 @@
-import {getAdditionalPermissions} from 'webext-additional-permissions';
+import {dropOverlappingPermissions, getAdditionalPermissions} from 'webext-additional-permissions';
 import {injectToExistingTabs} from './inject-to-existing-tabs.js';
 import {registerContentScript} from './register-content-script-shim.js';
 
@@ -67,8 +67,9 @@ export async function init() {
 	chrome.permissions.onRemoved.addListener(handledDroppedPermissions);
 	chrome.permissions.onAdded.addListener(handleNewPermissions);
 	await registerOnOrigins(
-		await getAdditionalPermissions({
-			strictOrigins: false,
-		}),
+		dropOverlappingPermissions(
+			await getAdditionalPermissions({
+				strictOrigins: false,
+			})),
 	);
 }

--- a/test/demo-extension/webext-additional-permissions.js
+++ b/test/demo-extension/webext-additional-permissions.js
@@ -1,7 +1,7 @@
 // Mock to fake a user-granted permission
 export function getAdditionalPermissions() {
 	return {
-		origins: ['https://dynamic-ephiframe.vercel.app/*'],
+		origins: ['https://dynamic-ephiframe.vercel.app/*', 'https://*.vercel.app/*'],
 		permissions: [],
 	};
 }


### PR DESCRIPTION
- Uses https://github.com/fregante/webext-additional-permissions#dropoverlappingpermissionspermissions
- Closes https://github.com/fregante/webext-dynamic-content-scripts/issues/35

This hasn't been an issue so far because v3 of the polyfill has a duplicate check, but it was dropped:

- https://github.com/fregante/webext-dynamic-content-scripts/pull/55

