### PR TITLE
Export utils.js for access to isContentScriptRegistered() (#67)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
 		"./including-active-tab.js": {
 			"types": "./distribution/including-active-tab.d.ts",
 			"default": "./distribution/including-active-tab.js"
+		},
+		"./utils.js": {
+			"types": "./distribution/utils.d.ts",
+			"default": "./distribution/utils.js"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
The `readme.md` says that the following works:

    ```js
    import {isContentScriptRegistered} from 'webext-dynamic-content-scripts/utils.js';

    if (await isContentScriptRegistered('https://google.com/search')) {
        console.log('Either way, the content scripts are registered');
    }
    ```

However the import fails, because the `exports` section in `package.json` doesn't export `utils.js`.  So add an entry to export it, thereby making the docs correct without needing to change them.

We don't add a wildcard entry to the `exports` section, because the intention is to explicitly export certain files, and hide the rest as internals.

It's also worth noting that the main file has side effects, so `utils.js` is exported separately for the benefit of consumers who need that but don't want the side effects.

Fixes #67.