### PR TITLE
Avoid duplicate injection on MV3 worker restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"content-scripts-register-polyfill": "^4.0.2",
 				"webext-content-scripts": "^2.6.1",
 				"webext-detect-page": "^5.0.1",
+				"webext-events": "^3.0.0",
 				"webext-patterns": "^1.4.0",
 				"webext-permissions": "^3.1.3",
 				"webext-polyfill-kinda": "^1.0.2"
@@ -13144,6 +13145,21 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-5.0.1.tgz",
 			"integrity": "sha512-HizogkTmviA5qA1yODwewzz4ETSc+N9bYrK6pEVIAP2kAG139Sg+3DOJixRnFYl2gFVZn4PBReDZhgmFOEVbeg==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
+		"node_modules/webext-events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/webext-events/-/webext-events-3.0.0.tgz",
+			"integrity": "sha512-RlqJXJV0zxn3rhuCv4l8fFddLvOCIyQACu+hVTSvL/AiC+bGvU7aaXZiTJ+WCqPcWFH8iu6SPPVJgvnCCtSlhg==",
+			"license": "MIT",
+			"dependencies": {
+				"webext-detect-page": "^5.0.1"
+			},
 			"engines": {
 				"node": ">=18"
 			},

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"content-scripts-register-polyfill": "^4.0.2",
 		"webext-content-scripts": "^2.6.1",
 		"webext-detect-page": "^5.0.1",
+		"webext-events": "^3.0.0",
 		"webext-patterns": "^1.4.0",
 		"webext-permissions": "^3.1.3",
 		"webext-polyfill-kinda": "^1.0.2"

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ navigator.importScripts('webext-dynamic-content-scripts.js');
 ```json
 // example manifest.json
 {
-	"permissions": ["scripting"],
+	"permissions": ["scripting", "storage"],
 	"optional_host_permissions": ["*://*/*"],
 	"background": {
 		"service_worker": "background.worker.js"

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,3 @@
 import {init} from './lib.js';
 
-void init();
+init();

--- a/source/inject-to-existing-tabs.ts
+++ b/source/inject-to-existing-tabs.ts
@@ -2,6 +2,8 @@ import {getTabsByUrl, injectContentScript} from 'webext-content-scripts';
 
 type ManifestContentScripts = NonNullable<chrome.runtime.Manifest['content_scripts']>;
 
+// May not be needed in the future in Firefox
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1458947
 export async function injectToExistingTabs(
 	origins: string[],
 	scripts: ManifestContentScripts,

--- a/source/lib.test.ts
+++ b/source/lib.test.ts
@@ -1,4 +1,3 @@
-import process from 'process';
 import {chrome} from 'jest-chrome';
 import {
 	describe, it, vi, beforeEach, expect,

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -79,12 +79,14 @@ async function registerExistingOrigins() {
 
 	const contentScripts = getContentScripts();
 	if (origins?.length) {
-		void injectToExistingTabs(origins, contentScripts);
-		void registerOnOrigins(origins, contentScripts);
+		await Promise.all([
+			injectToExistingTabs(origins, contentScripts),
+			registerOnOrigins(origins, contentScripts),
+		]);
 	}
 }
 
-export async function init() {
+export function init() {
 	chrome.permissions.onRemoved.addListener(handledDroppedPermissions);
 	chrome.permissions.onAdded.addListener(handleNewPermissions);
 	onExtensionStart.addListener(registerExistingOrigins);

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -51,10 +51,6 @@ async function registerOnOrigins(
 }
 
 async function handleNewPermissions({origins}: chrome.permissions.Permissions) {
-	if (!origins?.length) {
-		return;
-	}
-
 	await enableOnOrigins(origins);
 }
 
@@ -72,7 +68,7 @@ async function handledDroppedPermissions({origins}: chrome.permissions.Permissio
 	}
 }
 
-async function enableOnOrigins(origins: string[]) {
+async function enableOnOrigins(origins: string[] | undefined) {
 	if (!origins?.length) {
 		return;
 	}

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -55,7 +55,7 @@ async function handleNewPermissions({origins}: chrome.permissions.Permissions) {
 		return;
 	}
 
-	await registerOrigins(origins);
+	await enableOnOrigins(origins);
 }
 
 async function handledDroppedPermissions({origins}: chrome.permissions.Permissions) {
@@ -72,7 +72,7 @@ async function handledDroppedPermissions({origins}: chrome.permissions.Permissio
 	}
 }
 
-async function registerOrigins(origins: string[]) {
+async function enableOnOrigins(origins: string[]) {
 	if (!origins?.length) {
 		return;
 	}
@@ -89,7 +89,7 @@ async function registerExistingOrigins() {
 		strictOrigins: false,
 	});
 
-	await registerOrigins(origins);
+	await enableOnOrigins(origins);
 }
 
 export function init() {

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -1,4 +1,5 @@
 import {queryAdditionalPermissions} from 'webext-permissions';
+import {onExtensionStart} from 'webext-events';
 import {excludeDuplicateFiles} from './deduplicator.js';
 import {injectToExistingTabs} from './inject-to-existing-tabs.js';
 import {registerContentScript} from './register-content-script-shim.js';
@@ -13,25 +14,28 @@ function makePathRelative(file: string): string {
 	return new URL(file, location.origin).pathname;
 }
 
-// Automatically register the content scripts on the new origins
-async function registerOnOrigins({
-	origins: newOrigins,
-}: chrome.permissions.Permissions): Promise<void> {
-	if (!newOrigins?.length) {
-		return;
-	}
-
+function getContentScripts() {
 	const {content_scripts: rawManifest, manifest_version: manifestVersion} = chrome.runtime.getManifest();
 
 	if (!rawManifest) {
 		throw new Error('webext-dynamic-content-scripts tried to register scripts on the new host permissions, but no content scripts were found in the manifest.');
 	}
 
-	const cleanManifest = excludeDuplicateFiles(rawManifest, {warn: manifestVersion === 2});
+	return excludeDuplicateFiles(rawManifest, {warn: manifestVersion === 2});
+}
+
+// Automatically register the content scripts on the new origins
+async function registerOnOrigins(
+	origins: string[],
+	contentScripts: ReturnType<typeof getContentScripts>,
+): Promise<void> {
+	if (origins.length === 0) {
+		return;
+	}
 
 	// Register one at a time to allow removing one at a time as well
-	for (const origin of newOrigins) {
-		for (const config of cleanManifest) {
+	for (const origin of origins) {
+		for (const config of contentScripts) {
 			const registeredScript = registerContentScript({
 				// Always convert paths here because we don't know whether Firefox MV3 will accept full URLs
 				js: config.js?.map(file => makePathRelative(file)),
@@ -44,14 +48,14 @@ async function registerOnOrigins({
 			registeredScripts.set(origin, registeredScript);
 		}
 	}
-
-	// May not be needed in the future in Firefox
-	// https://bugzilla.mozilla.org/show_bug.cgi?id=1458947
-	void injectToExistingTabs(newOrigins, cleanManifest);
 }
 
-function handleNewPermissions(permissions: chrome.permissions.Permissions) {
-	void registerOnOrigins(permissions);
+function handleNewPermissions({origins}: chrome.permissions.Permissions) {
+	const contentScripts = getContentScripts();
+	if (origins?.length) {
+		void injectToExistingTabs(origins, contentScripts);
+		void registerOnOrigins(origins, contentScripts);
+	}
 }
 
 async function handledDroppedPermissions({origins}: chrome.permissions.Permissions) {
@@ -68,12 +72,20 @@ async function handledDroppedPermissions({origins}: chrome.permissions.Permissio
 	}
 }
 
+async function registerExistingOrigins() {
+	const {origins} = await queryAdditionalPermissions({
+		strictOrigins: false,
+	});
+
+	const contentScripts = getContentScripts();
+	if (origins?.length) {
+		void injectToExistingTabs(origins, contentScripts);
+		void registerOnOrigins(origins, contentScripts);
+	}
+}
+
 export async function init() {
 	chrome.permissions.onRemoved.addListener(handledDroppedPermissions);
 	chrome.permissions.onAdded.addListener(handleNewPermissions);
-	await registerOnOrigins(
-		await queryAdditionalPermissions({
-			strictOrigins: false,
-		}),
-	);
+	onExtensionStart.addListener(registerExistingOrigins);
 }

--- a/test/demo-extension/mv3/manifest.json
+++ b/test/demo-extension/mv3/manifest.json
@@ -2,7 +2,7 @@
 	"name": "webext-dynamic-content-scripts-mv3",
 	"version": "0.0.0",
 	"manifest_version": 3,
-	"permissions": ["webNavigation", "scripting", "contextMenus", "activeTab"],
+	"permissions": ["webNavigation", "scripting", "contextMenus", "activeTab", "storage"],
 	"host_permissions": [
 		"https://dynamic-ephiframe.vercel.app/*",
 		"https://accepted-ephiframe.vercel.app/*"


### PR DESCRIPTION
I don't know if the `storage` permission is required. Untested.